### PR TITLE
chore: override tar-fs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,9 +1569,10 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "node-schedule": "^2.1.1",
     "sqlite3": "^5.1.7",
     "undici": "^7.15.0"
+  },
+  "overrides": {
+    "tar-fs": "^2.1.3"
   }
 }


### PR DESCRIPTION
## Summary
- override tar-fs to patched release via npm overrides

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b353247b7c8324b3dae41402eca5a8