### PR TITLE
Add safe tar extraction helper and tests

### DIFF
--- a/test/safeExtract.test.js
+++ b/test/safeExtract.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const tar = require('tar-stream');
+const { safeExtract } = require('../utils/safeExtract');
+
+test('ignores files with ../ paths', async () => {
+  const pack = tar.pack();
+  pack.entry({ name: '../evil.txt' }, 'evil');
+  pack.finalize();
+
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'safex-'));
+  const dest = path.join(baseDir, 'extract');
+  fs.mkdirSync(dest);
+
+  await safeExtract(pack, dest);
+  assert.ok(fs.existsSync(path.join(dest, 'evil.txt')));
+  assert.ok(!fs.existsSync(path.join(baseDir, 'evil.txt')));
+});
+
+test('ignores symlink entries', async () => {
+  const pack = tar.pack();
+  pack.entry({ name: 'link', type: 'symlink', linkname: '../evil.txt' });
+  pack.finalize();
+
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'safex-'));
+  const dest = path.join(baseDir, 'extract');
+  fs.mkdirSync(dest);
+
+  await safeExtract(pack, dest);
+
+  assert.ok(!fs.existsSync(path.join(dest, 'link')));
+  assert.ok(!fs.existsSync(path.join(baseDir, 'evil.txt')));
+});

--- a/utils/safeExtract.js
+++ b/utils/safeExtract.js
@@ -1,0 +1,46 @@
+const tar = require('tar-fs');
+const path = require('path');
+
+/**
+ * Safely extract a tar archive stream into a destination directory.
+ * Entries that would write outside the destination or contain
+ * symbolic links are ignored.
+ *
+ * @param {stream.Readable} stream - tar archive stream
+ * @param {string} dest - destination directory
+ * @param {object} [options] - optional tar-fs options
+ * @returns {Promise<void>} resolves when extraction finishes
+ */
+function safeExtract(stream, dest, options = {}) {
+  const root = path.resolve(dest) + path.sep;
+
+  return new Promise((resolve, reject) => {
+    const extractor = tar.extract(dest, {
+      ...options,
+      // ensure map is executed before our path checks
+      map: (header) => {
+        if (options.map) header = options.map(header) || header;
+        header.name = path
+          .normalize(header.name)
+          .replace(/^(\.\.([/\\]|$))+/, '')
+          .replace(/^[/\\]+/, '');
+        return header;
+      },
+      ignore: (name, header) => {
+        if (typeof options.ignore === 'function' && options.ignore(name, header)) {
+          return true;
+        }
+        if (header.type === 'symlink' || header.type === 'link') {
+          return true;
+        }
+        return !name.startsWith(root);
+      },
+    });
+
+    extractor.on('finish', resolve);
+    extractor.on('error', reject);
+    stream.pipe(extractor);
+  });
+}
+
+module.exports = { safeExtract };


### PR DESCRIPTION
## Summary
- add `safeExtract` utility wrapping `tar-fs` extraction with path sanitization and symlink filtering
- cover traversal and symlink edge cases with unit tests

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b35cca99d483249a7ede8b85528b19