### PR TITLE
feat: use Discord API v10 for command deployment

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -3,6 +3,7 @@
 
 require("dotenv").config();
 const fs = require("fs");
+const { Routes } = require("discord-api-types/v10");
 const { fetchWithRetry } = require("./utils/http");
 
 const commands = [];
@@ -23,10 +24,15 @@ for (const file of commandFiles) {
       "Content-Type": "application/json",
       Authorization: `Bot ${process.env.TOKEN}`,
     };
-    const baseUrl = "https://discord.com/api/v9";
+    const baseUrl = "https://discord.com/api/v10";
 
     if (process.env.GUILD_ID) {
-      const url = `${baseUrl}/applications/${process.env.CLIENT_ID}/guilds/${process.env.GUILD_ID}/commands`;
+      const url =
+        baseUrl +
+        Routes.applicationGuildCommands(
+          process.env.CLIENT_ID,
+          process.env.GUILD_ID
+        );
       const res = await fetchWithRetry(url, {
         method: "PUT",
         headers,
@@ -39,7 +45,7 @@ for (const file of commandFiles) {
         "Successfully reloaded guild-specific application (/) commands."
       );
     } else {
-      const url = `${baseUrl}/applications/${process.env.CLIENT_ID}/commands`;
+      const url = baseUrl + Routes.applicationCommands(process.env.CLIENT_ID);
       const res = await fetchWithRetry(url, {
         method: "PUT",
         headers,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,8 +4,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "BibleRef",
       "dependencies": {
+        "discord-api-types": "^0.38.22",
         "discord.js": "^14.15.3",
         "dotenv": "^16.4.5",
         "moment-timezone": "^0.5.45",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "discord-api-types": "^0.38.22",
     "discord.js": "^14.15.3",
     "dotenv": "^16.4.5",
     "moment-timezone": "^0.5.45",


### PR DESCRIPTION
## Summary
- switch command deploy script to Discord API v10 and use typed Routes
- add discord-api-types v10 dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b36c01fd648324be16141c39f82fcc