### PR TITLE
chore: streamline bot intents

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,8 @@ const { setupDailyVerse } = require("./scheduler/dailyVerseScheduler"); // Corre
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildMessages,
-    GatewayIntentBits.MessageContent,
+    // Retain GuildMessageReactions for reaction-based trivia games
     GatewayIntentBits.GuildMessageReactions,
-    GatewayIntentBits.DirectMessageReactions,
   ],
 });
 


### PR DESCRIPTION
## Summary
- prune unused gateway intents from Discord client
- retain guild reaction intent for reaction-based trivia games

## Testing
- `node --check index.js`
- `node --check commands/brtrivia.js`
- `node --check deploy-commands.js`
- `node test/safeExtract.test.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b36d0866608324aa579e8471504e2d