### PR TITLE
refactor: use node-cron for daily verse scheduler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "dotenv": "^16.4.5",
         "moment-timezone": "^0.5.45",
         "node-cron": "^3.0.3",
-        "node-schedule": "^2.1.1",
         "sqlite3": "^5.1.7",
         "undici": "^7.15.0"
       }
@@ -489,18 +488,6 @@
       "license": "ISC",
       "optional": true
     },
-    "node_modules/cron-parser": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
-      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "luxon": "^3.2.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -944,12 +931,6 @@
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
     },
-    "node_modules/long-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
-      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -961,15 +942,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
-      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/magic-bytes.js": {
@@ -1250,20 +1222,6 @@
       },
       "engines": {
         "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/node-schedule": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
-      "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cron-parser": "^4.2.0",
-        "long-timeout": "0.1.1",
-        "sorted-array-functions": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/nopt": {
@@ -1585,12 +1543,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/sorted-array-functions": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
-      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
-      "license": "MIT"
     },
     "node_modules/sqlite3": {
       "version": "5.1.7",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "dotenv": "^16.4.5",
     "moment-timezone": "^0.5.45",
     "node-cron": "^3.0.3",
-    "node-schedule": "^2.1.1",
     "sqlite3": "^5.1.7",
     "undici": "^7.15.0"
   },

--- a/scheduler/dailyVerseScheduler.js
+++ b/scheduler/dailyVerseScheduler.js
@@ -1,8 +1,7 @@
 // scheduler/dailyVerseScheduler.js
 const fs = require("fs");
 const path = require("path");
-const moment = require("moment-timezone");
-const { scheduleJob } = require("node-schedule");
+const cron = require("node-cron");
 const sqlite3 = require("sqlite3").verbose();
 const dbPath = path.join(__dirname, "..", "kjv_pure.db");
 
@@ -16,32 +15,40 @@ function setupDailyVerse(client) {
 
   const [hour, minute] = time.split(":").map((num) => parseInt(num, 10));
 
-  scheduleJob({ hour, minute, tz: timezone }, function () {
-    const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READONLY, (err) => {
-      if (err) {
-        console.error("Error opening database:", err.message);
-      } else {
-        db.get(
-          "SELECT verse_text, book_name FROM kjv_pure ORDER BY RANDOM() LIMIT 1",
-          (err, row) => {
-            if (err) {
-              console.error(err.message);
-              return;
-            }
+  cron.schedule(
+    `${minute} ${hour} * * *`,
+    function () {
+      const db = new sqlite3.Database(
+        dbPath,
+        sqlite3.OPEN_READONLY,
+        (err) => {
+          if (err) {
+            console.error("Error opening database:", err.message);
+          } else {
+            db.get(
+              "SELECT verse_text, book_name FROM kjv_pure ORDER BY RANDOM() LIMIT 1",
+              (err, row) => {
+                if (err) {
+                  console.error(err.message);
+                  return;
+                }
 
-            currentDailyVerse = `${row.book_name}: ${row.verse_text}`;
+                currentDailyVerse = `${row.book_name}: ${row.verse_text}`;
 
-            const channel = client.channels.cache.get(channelId);
-            if (channel) {
-              channel.send(currentDailyVerse);
-            } else {
-              console.error("Channel not found:", channelId);
-            }
+                const channel = client.channels.cache.get(channelId);
+                if (channel) {
+                  channel.send(currentDailyVerse);
+                } else {
+                  console.error("Channel not found:", channelId);
+                }
+              }
+            );
           }
-        );
-      }
-    });
-  });
+        }
+      );
+    },
+    { timezone }
+  );
 }
 
 function getCurrentDailyVerse() {


### PR DESCRIPTION
## Summary
- replace node-schedule with node-cron in daily verse scheduler
- remove node-schedule dependency

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test")*
- manual run of daily verse scheduler to confirm message sent

------
https://chatgpt.com/codex/tasks/task_e_68b36de706d0832496478adb4d9069c0