### PR TITLE
Handle command loading errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,14 @@ fs.readdir(commandsPath, (err, files) => {
     .filter((file) => file.endsWith(".js"))
     .forEach((file) => {
       const filePath = path.join(commandsPath, file);
-      const command = require(filePath);
-      client.commands.set(command.data.name, command);
+      try {
+        const command = require(filePath);
+        client.commands.set(command.data.name, command);
+        // Optional debug log for successful loads
+        console.log(`Loaded command: ${file}`);
+      } catch (err) {
+        console.error(`Failed to load command ${file}:`, err);
+      }
     });
 });
 


### PR DESCRIPTION
## Summary
- prevent command loader from crashing by wrapping each `require` in a try/catch
- log failed command file names and note successful loads for debugging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b3736be7dc832488805a032e8d6a5b