### PR TITLE
feat: add FTS search tables and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ BibleRef is a comprehensive tool for Bible study and engagement, featuring the f
 
 To get started with this bot, you will need to have a hosting solution for Node.js and the host will need to allow more than one sqlite database. Check the setup guide for details. Clone the repository, configure the necessary settings in the config.json file, and run the bot on your server. The bot is designed to be easy to deploy and customize, making it a great addition to any Discord community focused on Bible study and fellowship.
 
+## Full-text Search
+
+SQLite FTS5 virtual tables power fast searches. Create and populate them with:
+
+```
+node db/migrate-fts.js
+```
+
+Run the script whenever the base databases change to rebuild the indexes. Triggers keep the FTS tables synchronized with `kjv` and `kjv_pure`.
+
 ## Commands:
 
     /brsearch Luke 1:1-3 or Luke - Retrieve all information matching search term.

--- a/SearchEngine.js
+++ b/SearchEngine.js
@@ -40,48 +40,47 @@ class SearchEngine {
   }
 
   async search(term) {
-    const searchTerm = `%${term}%`;
     try {
       const results = await Promise.all([
         this.queryDatabase(
           "dbDict",
-          "SELECT * FROM dictionary WHERE key LIKE ? OR transliteration LIKE ? OR definitions LIKE ?",
-          [searchTerm, searchTerm, searchTerm]
+          "SELECT d.*, snippet(dictionary_fts, -1, '<b>', '</b>', '...', 10) AS snippet FROM dictionary_fts JOIN dictionary d ON dictionary_fts.rowid = d.rowid WHERE dictionary_fts MATCH ?",
+          [term]
         ),
         this.queryDatabase(
           "dbPure",
-          "SELECT * FROM strong_pure WHERE text_part LIKE ?",
-          [searchTerm]
+          "SELECT sp.*, snippet(strong_pure_fts, -1, '<b>', '</b>', '...', 10) AS snippet FROM strong_pure_fts JOIN strong_pure sp ON strong_pure_fts.rowid = sp.rowid WHERE strong_pure_fts MATCH ?",
+          [term]
         ),
         this.queryDatabase(
           "dbWords",
-          "SELECT * FROM strong_words WHERE strong_id LIKE ?",
-          [searchTerm]
+          "SELECT sw.*, snippet(strong_words_fts, -1, '<b>', '</b>', '...', 10) AS snippet FROM strong_words_fts JOIN strong_words sw ON strong_words_fts.rowid = sw.rowid WHERE strong_words_fts MATCH ?",
+          [term]
         ),
         this.queryDatabase(
           "dbAcrostics",
-          "SELECT * FROM acrostics WHERE value LIKE ?",
-          [searchTerm]
+          "SELECT a.*, snippet(acrostics_fts, -1, '<b>', '</b>', '...', 10) AS snippet FROM acrostics_fts JOIN acrostics a ON acrostics_fts.rowid = a.rowid WHERE acrostics_fts MATCH ?",
+          [term]
         ),
         this.queryDatabase(
           "dbBooks",
-          "SELECT * FROM books WHERE name LIKE ? OR abbreviation LIKE ?",
-          [searchTerm, searchTerm]
+          "SELECT b.*, snippet(books_fts, -1, '<b>', '</b>', '...', 10) AS snippet FROM books_fts JOIN books b ON books_fts.rowid = b.rowid WHERE books_fts MATCH ?",
+          [term]
         ),
         this.queryDatabase(
           "dbCitations",
-          "SELECT * FROM kjv_citations WHERE citation LIKE ?",
-          [searchTerm]
+          "SELECT c.*, snippet(kjv_citations_fts, -1, '<b>', '</b>', '...', 10) AS snippet FROM kjv_citations_fts JOIN kjv_citations c ON kjv_citations_fts.rowid = c.rowid WHERE kjv_citations_fts MATCH ?",
+          [term]
         ),
         this.queryDatabase(
           "dbChapters",
-          "SELECT * FROM chapters WHERE chapter_name LIKE ? OR chapter_number LIKE ?",
-          [searchTerm, searchTerm]
+          "SELECT ch.*, snippet(chapters_fts, -1, '<b>', '</b>', '...', 10) AS snippet FROM chapters_fts JOIN chapters ch ON chapters_fts.rowid = ch.rowid WHERE chapters_fts MATCH ?",
+          [term]
         ),
         this.queryDatabase(
           "dbKjvPure",
-          "SELECT * FROM kjv_pure WHERE verse_text LIKE ?",
-          [searchTerm]
+          "SELECT kp.*, snippet(kjv_pure_fts, 0, '<b>', '</b>', '...', 10) AS snippet FROM kjv_pure_fts JOIN kjv_pure kp ON kjv_pure_fts.rowid = kp.rowid WHERE kjv_pure_fts MATCH ?",
+          [term]
         ),
       ]);
 

--- a/db/migrate-fts.js
+++ b/db/migrate-fts.js
@@ -1,0 +1,71 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const fs = require('fs');
+
+const configs = [
+  {
+    file: path.join(__dirname, '..', 'kjv_bible.db'),
+    ftsTable: 'kjv_fts',
+    contentTable: 'kjv',
+    contentRowid: 'id',
+    columns: ['book_name', 'text'],
+  },
+  {
+    file: path.join(__dirname, '..', 'kjv_pure.db'),
+    ftsTable: 'kjv_pure_fts',
+    contentTable: 'kjv_pure',
+    contentRowid: 'rowid',
+    columns: ['verse_text'],
+  },
+];
+
+configs.forEach((cfg) => {
+  if (!fs.existsSync(cfg.file)) {
+    console.warn(`Database not found: ${cfg.file}, skipping.`);
+    return;
+  }
+  const db = new sqlite3.Database(cfg.file);
+  const colsDef = cfg.columns.join(', ');
+  const colNames = cfg.columns.join(', ');
+  const newCols = cfg.columns.map((c) => `NEW.${c}`).join(', ');
+
+  db.get(
+    `SELECT name FROM sqlite_master WHERE type='table' AND name=?`,
+    [cfg.contentTable],
+    (err, row) => {
+      if (err || !row) {
+        console.warn(`Table ${cfg.contentTable} not found in ${cfg.file}, skipping.`);
+        db.close();
+        return;
+      }
+
+      db.serialize(() => {
+        db.run(
+          `CREATE VIRTUAL TABLE IF NOT EXISTS ${cfg.ftsTable} USING fts5(${colsDef}, content='${cfg.contentTable}', content_rowid='${cfg.contentRowid}')`
+        );
+        db.run(`INSERT INTO ${cfg.ftsTable}(${cfg.ftsTable}) VALUES('rebuild')`);
+
+        db.run(
+          `CREATE TRIGGER IF NOT EXISTS ${cfg.contentTable}_ai AFTER INSERT ON ${cfg.contentTable} BEGIN
+             INSERT INTO ${cfg.ftsTable}(rowid, ${colNames}) VALUES (NEW.${cfg.contentRowid}, ${newCols});
+           END;`
+        );
+        db.run(
+          `CREATE TRIGGER IF NOT EXISTS ${cfg.contentTable}_ad AFTER DELETE ON ${cfg.contentTable} BEGIN
+             INSERT INTO ${cfg.ftsTable}(${cfg.ftsTable}, rowid) VALUES('delete', OLD.${cfg.contentRowid});
+           END;`
+        );
+        db.run(
+          `CREATE TRIGGER IF NOT EXISTS ${cfg.contentTable}_au AFTER UPDATE ON ${cfg.contentTable} BEGIN
+             INSERT INTO ${cfg.ftsTable}(${cfg.ftsTable}, rowid) VALUES('delete', OLD.${cfg.contentRowid});
+             INSERT INTO ${cfg.ftsTable}(rowid, ${colNames}) VALUES (NEW.${cfg.contentRowid}, ${newCols});
+           END;`
+        );
+      });
+
+      db.close();
+    }
+  );
+});
+
+console.log('FTS migration completed.');


### PR DESCRIPTION
## Summary
- add migration script to build FTS5 tables and triggers
- switch `SearchEngine` and `/brsearch` to FTS-backed `MATCH` queries with snippets
- document FTS initialization and rebuild steps

## Testing
- `node db/migrate-fts.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b37bd879ec8324a108383813d6d9ca