### PR TITLE
Refactor SearchEngine for lazy connections and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ node db/migrate-fts.js
 
 Run the script whenever the base databases change to rebuild the indexes. Triggers keep the FTS tables synchronized with `kjv` and `kjv_pure`.
 
+### Search engine options
+
+`SearchEngine` lazily opens SQLite databases and caches prepared statements. You can tweak its behavior with:
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `timeout` | Milliseconds a connection may remain idle before being closed. | `300000` |
+| `cacheSize` | Maximum number of prepared statements retained in an LRU cache. | `100` |
+
+```js
+const SearchEngine = require("./SearchEngine");
+const engine = new SearchEngine({ timeout: 300000, cacheSize: 100 });
+```
+
 ## Commands:
 
     /brsearch Luke 1:1-3 or Luke - Retrieve all information matching search term.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "discord-api-types": "^0.38.22",
         "discord.js": "^14.15.3",
         "dotenv": "^16.4.5",
+        "lru-cache": "^10.4.3",
         "moment-timezone": "^0.5.45",
         "node-cron": "^3.0.3",
         "sqlite3": "^5.1.7",
@@ -443,6 +444,19 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/chownr": {
@@ -932,17 +946,10 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/magic-bytes.js": {
       "version": "1.12.1",
@@ -976,6 +983,19 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mimic-response": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "discord-api-types": "^0.38.22",
     "discord.js": "^14.15.3",
     "dotenv": "^16.4.5",
+    "lru-cache": "^10.4.3",
     "moment-timezone": "^0.5.45",
     "node-cron": "^3.0.3",
     "sqlite3": "^5.1.7",


### PR DESCRIPTION
## Summary
- Lazy-open SQLite connections using `getConnection` and close them after inactivity
- Cache prepared statements with an LRU strategy and configurable size
- Document new `timeout` and `cacheSize` options for the search engine

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b37d4389708324ba4d6f3dacd99864