### PR TITLE
refactor brsearch to use SearchEngine

### DIFF
--- a/SearchEngine.js
+++ b/SearchEngine.js
@@ -93,6 +93,14 @@ class SearchEngine {
     });
   }
 
+  async searchKjv(term) {
+    return this.queryDatabase(
+      "dbKjvPure",
+      "SELECT kp.book_name, kp.chapter, kp.verse, kp.text, snippet(kjv_pure_fts, 0, '<b>', '</b>', '...', 10) AS snippet FROM kjv_pure_fts JOIN kjv_pure kp ON kjv_pure_fts.rowid = kp.rowid WHERE kjv_pure_fts MATCH ?",
+      [term]
+    );
+  }
+
   async search(term) {
     try {
       const results = await Promise.all([


### PR DESCRIPTION
## Summary
- Replace direct SQLite access in `brsearch` with the shared `SearchEngine`
- Add `searchKjv` helper for Bible FTS queries
- Show highlighted snippets in paginated search results

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b37f28ad1c8324837dcea8615bf57a