### PR TITLE
Add book utilities and translation database helper

### DIFF
--- a/src/db/translations.js
+++ b/src/db/translations.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const FILES = {
+  kjv: 'kjv_strongs.sqlite',
+  asv: 'asvs.sqlite',
+};
+
+function openDatabase(translation = 'kjv', options = {}) {
+  const file = FILES[translation.toLowerCase()];
+  if (!file) throw new Error(`Unknown translation: ${translation}`);
+  const dbPath = path.join(__dirname, '..', '..', 'db', file);
+  const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READWRITE);
+  const state = { db, columns: null, hasFts: false };
+
+  return introspect(state)
+    .then(() => ensureFts(state, options.fts))
+    .then(() => ({
+      getVerse: (book, chapter, verse) => getVerse(state, book, chapter, verse),
+      search: (q, limit) => search(state, q, limit),
+      close: () => db.close(),
+    }));
+}
+
+function introspect(state) {
+  return new Promise((resolve, reject) => {
+    state.db.all('PRAGMA table_info(verses)', (err, rows) => {
+      if (err) return reject(err);
+      const cols = {};
+      rows.forEach((r) => {
+        const name = r.name.toLowerCase();
+        if (name === 'id') cols.id = r.name;
+        else if (name.includes('book')) cols.book = r.name;
+        else if (name.includes('chapter')) cols.chapter = r.name;
+        else if (name.includes('verse')) cols.verse = r.name;
+        else if (name.includes('text')) cols.text = r.name;
+      });
+      state.columns = cols;
+      resolve();
+    });
+  });
+}
+
+function tableExists(db, table) {
+  return new Promise((resolve) => {
+    db.get(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+      [table],
+      (err, row) => resolve(!!row)
+    );
+  });
+}
+
+function ensureFts(state, build) {
+  return tableExists(state.db, 'verses_fts').then((exists) => {
+    state.hasFts = exists;
+    if (exists || !build) return;
+    const c = state.columns;
+    const sql = `CREATE VIRTUAL TABLE verses_fts USING fts5(${c.text}, content='verses', content_rowid='${c.id}')`;
+    return run(state.db, sql)
+      .then(() => run(state.db, "INSERT INTO verses_fts(verses_fts) VALUES('rebuild')"))
+      .then(() => {
+        state.hasFts = true;
+      })
+      .catch(() => {});
+  });
+}
+
+function run(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function getVerse(state, book, chapter, verse) {
+  const c = state.columns;
+  const sql = `SELECT ${c.book} AS book, ${c.chapter} AS chapter, ${c.verse} AS verse, ${c.text} AS text FROM verses WHERE ${c.book}=? AND ${c.chapter}=? AND ${c.verse}=? LIMIT 1`;
+  return new Promise((resolve, reject) => {
+    state.db.get(sql, [book, chapter, verse], (err, row) => {
+      if (err) reject(err);
+      else resolve(row || null);
+    });
+  });
+}
+
+function search(state, query, limit = 10) {
+  const c = state.columns;
+  if (state.hasFts) {
+    const sql = `SELECT v.${c.book} AS book, v.${c.chapter} AS chapter, v.${c.verse} AS verse, snippet(verses_fts, 0, '<b>', '</b>', '...', 10) AS snippet FROM verses_fts JOIN verses v ON verses_fts.rowid = v.${c.id} WHERE verses_fts MATCH ? LIMIT ?`;
+    return all(state.db, sql, [query, limit]);
+  } else {
+    const sql = `SELECT ${c.book} AS book, ${c.chapter} AS chapter, ${c.verse} AS verse, ${c.text} AS snippet FROM verses WHERE ${c.text} LIKE ? LIMIT ?`;
+    return all(state.db, sql, [`%${query}%`, limit]);
+  }
+}
+
+function all(db, sql, params) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => (err ? reject(err) : resolve(rows)));
+  });
+}
+
+module.exports = { openDatabase };

--- a/src/lib/books.js
+++ b/src/lib/books.js
@@ -1,0 +1,106 @@
+const books = [
+  null,
+  'Genesis',
+  'Exodus',
+  'Leviticus',
+  'Numbers',
+  'Deuteronomy',
+  'Joshua',
+  'Judges',
+  'Ruth',
+  '1 Samuel',
+  '2 Samuel',
+  '1 Kings',
+  '2 Kings',
+  '1 Chronicles',
+  '2 Chronicles',
+  'Ezra',
+  'Nehemiah',
+  'Esther',
+  'Job',
+  'Psalms',
+  'Proverbs',
+  'Ecclesiastes',
+  'Song of Solomon',
+  'Isaiah',
+  'Jeremiah',
+  'Lamentations',
+  'Ezekiel',
+  'Daniel',
+  'Hosea',
+  'Joel',
+  'Amos',
+  'Obadiah',
+  'Jonah',
+  'Micah',
+  'Nahum',
+  'Habakkuk',
+  'Zephaniah',
+  'Haggai',
+  'Zechariah',
+  'Malachi',
+  'Matthew',
+  'Mark',
+  'Luke',
+  'John',
+  'Acts',
+  'Romans',
+  '1 Corinthians',
+  '2 Corinthians',
+  'Galatians',
+  'Ephesians',
+  'Philippians',
+  'Colossians',
+  '1 Thessalonians',
+  '2 Thessalonians',
+  '1 Timothy',
+  '2 Timothy',
+  'Titus',
+  'Philemon',
+  'Hebrews',
+  'James',
+  '1 Peter',
+  '2 Peter',
+  '1 John',
+  '2 John',
+  '3 John',
+  'Jude',
+  'Revelation',
+];
+
+function normalize(name) {
+  if (!name) return '';
+  const roman = { i: '1', ii: '2', iii: '3' };
+  let n = name.trim().toLowerCase();
+  n = n.replace(/^(i{1,3})\b/, (m) => roman[m] || m);
+  n = n.replace(/[^a-z0-9]/g, '');
+  return n;
+}
+
+const map = {};
+books.forEach((b, i) => {
+  if (!b) return;
+  map[normalize(b)] = i;
+});
+
+const aliases = {
+  songofsongs: 22,
+  canticles: 22,
+  revelations: 66,
+};
+for (const [k, v] of Object.entries(aliases)) {
+  map[normalize(k)] = v;
+}
+
+function idToName(id) {
+  return books[id] || null;
+}
+
+function nameToId(name) {
+  const norm = normalize(name);
+  if (map[norm]) return map[norm];
+  const matches = Object.entries(map).filter(([k]) => k.startsWith(norm) || norm.startsWith(k));
+  return matches.length === 1 ? matches[0][1] : null;
+}
+
+module.exports = { books, idToName, nameToId };

--- a/test/books.test.js
+++ b/test/books.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { idToName, nameToId } = require('../src/lib/books');
+
+test('idToName basic mapping', () => {
+  assert.equal(idToName(1), 'Genesis');
+});
+
+test('nameToId tolerant parsing', () => {
+  assert.equal(nameToId('gen'), 1);
+  assert.equal(nameToId('II Kings'), 12);
+  assert.equal(nameToId('song of songs'), 22);
+  assert.equal(nameToId('Revelations'), 66);
+  assert.equal(nameToId('i john'), 62);
+});

--- a/test/translations.test.js
+++ b/test/translations.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { openDatabase } = require('../src/db/translations');
+const { nameToId } = require('../src/lib/books');
+
+test('getVerse retrieves verse', async () => {
+  const db = await openDatabase('kjv');
+  const john = nameToId('John');
+  const verse = await db.getVerse(john, 3, 16);
+  assert.ok(verse && verse.text.includes('God'));
+  db.close();
+});
+
+test('search finds verse', async () => {
+  const db = await openDatabase('kjv');
+  const results = await db.search('only begotten', 10);
+  const john = nameToId('John');
+  assert.ok(results.some(r => r.book === john && r.chapter === 3 && r.verse === 16));
+  db.close();
+});


### PR DESCRIPTION
## Summary
- provide book name/id mappings with tolerant parsing for abbreviations and roman numerals
- add translation database helper that discovers schema, optional FTS, and exposes getVerse/search
- test new utilities and database wrapper

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b39a09c0d08324a137a5b70924c823