### PR TITLE
Add FTS migration script for verse databases

### DIFF
--- a/db/migrate-fts.js
+++ b/db/migrate-fts.js
@@ -2,70 +2,72 @@ const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
 const fs = require('fs');
 
-const configs = [
-  {
-    file: path.join(__dirname, 'kjv_strongs.sqlite'),
-    ftsTable: 'verses_fts',
-    contentTable: 'verses',
-    contentRowid: 'id',
-    columns: ['book', 'chapter', 'verse', 'text'],
-  },
-  {
-    file: path.join(__dirname, 'asvs.sqlite'),
-    ftsTable: 'verses_fts',
-    contentTable: 'verses',
-    contentRowid: 'id',
-    columns: ['book', 'chapter', 'verse', 'text'],
-  },
-];
+// Databases to process
+const dbFiles = ['asvs.sqlite', 'kjv_strongs.sqlite'];
 
-configs.forEach((cfg) => {
-  if (!fs.existsSync(cfg.file)) {
-    console.warn(`Database not found: ${cfg.file}, skipping.`);
+// Optionally rebuild the FTS index contents
+const rebuild = process.argv.includes('--rebuild');
+
+dbFiles.forEach((fileName) => {
+  const filePath = path.join(__dirname, fileName);
+
+  if (!fs.existsSync(filePath)) {
+    console.warn(`Database not found: ${filePath}, skipping.`);
     return;
   }
-  const db = new sqlite3.Database(cfg.file);
-  const colsDef = cfg.columns.join(', ');
-  const colNames = cfg.columns.join(', ');
-  const newCols = cfg.columns.map((c) => `NEW.${c}`).join(', ');
 
-  db.get(
-    `SELECT name FROM sqlite_master WHERE type='table' AND name=?`,
-    [cfg.contentTable],
-    (err, row) => {
-      if (err || !row) {
-        console.warn(`Table ${cfg.contentTable} not found in ${cfg.file}, skipping.`);
-        db.close();
-        return;
+  const db = new sqlite3.Database(filePath);
+
+  db.all(`PRAGMA table_info(verses)`, (err, columns) => {
+    if (err || columns.length === 0) {
+      console.warn(`Table verses not found in ${filePath}, skipping.`);
+      db.close();
+      return;
+    }
+
+    const columnNames = columns.map((c) => c.name).filter((name) => name !== 'id');
+
+    if (columnNames.length === 0) {
+      console.warn(`No columns found for verses table in ${filePath}, skipping.`);
+      db.close();
+      return;
+    }
+
+    const colsDef = columnNames.join(', ');
+    const colList = columnNames.join(', ');
+    const newCols = columnNames.map((c) => `NEW.${c}`).join(', ');
+
+    db.serialize(() => {
+      db.run(
+        `CREATE VIRTUAL TABLE IF NOT EXISTS verses_fts USING fts5(${colsDef}, content='verses', content_rowid='id')`
+      );
+
+      if (rebuild) {
+        db.run(`INSERT INTO verses_fts(verses_fts) VALUES('rebuild')`);
       }
 
-      db.serialize(() => {
-        db.run(
-          `CREATE VIRTUAL TABLE IF NOT EXISTS ${cfg.ftsTable} USING fts5(${colsDef}, content='${cfg.contentTable}', content_rowid='${cfg.contentRowid}')`
-        );
-        db.run(`INSERT INTO ${cfg.ftsTable}(${cfg.ftsTable}) VALUES('rebuild')`);
+      db.run(
+        `CREATE TRIGGER IF NOT EXISTS verses_ai AFTER INSERT ON verses BEGIN
+           INSERT INTO verses_fts(rowid, ${colList}) VALUES (NEW.id, ${newCols});
+         END;`
+      );
 
-        db.run(
-          `CREATE TRIGGER IF NOT EXISTS ${cfg.contentTable}_ai AFTER INSERT ON ${cfg.contentTable} BEGIN
-             INSERT INTO ${cfg.ftsTable}(rowid, ${colNames}) VALUES (NEW.${cfg.contentRowid}, ${newCols});
-           END;`
-        );
-        db.run(
-          `CREATE TRIGGER IF NOT EXISTS ${cfg.contentTable}_ad AFTER DELETE ON ${cfg.contentTable} BEGIN
-             INSERT INTO ${cfg.ftsTable}(${cfg.ftsTable}, rowid) VALUES('delete', OLD.${cfg.contentRowid});
-           END;`
-        );
-        db.run(
-          `CREATE TRIGGER IF NOT EXISTS ${cfg.contentTable}_au AFTER UPDATE ON ${cfg.contentTable} BEGIN
-             INSERT INTO ${cfg.ftsTable}(${cfg.ftsTable}, rowid) VALUES('delete', OLD.${cfg.contentRowid});
-             INSERT INTO ${cfg.ftsTable}(rowid, ${colNames}) VALUES (NEW.${cfg.contentRowid}, ${newCols});
-           END;`
-        );
-      });
+      db.run(
+        `CREATE TRIGGER IF NOT EXISTS verses_ad AFTER DELETE ON verses BEGIN
+           INSERT INTO verses_fts(verses_fts, rowid) VALUES('delete', OLD.id);
+         END;`
+      );
 
-      db.close();
-    }
-  );
+      db.run(
+        `CREATE TRIGGER IF NOT EXISTS verses_au AFTER UPDATE ON verses BEGIN
+           INSERT INTO verses_fts(verses_fts, rowid) VALUES('delete', OLD.id);
+           INSERT INTO verses_fts(rowid, ${colList}) VALUES (NEW.id, ${newCols});
+         END;`,
+        () => db.close()
+      );
+    });
+  });
 });
 
 console.log('FTS migration completed.');
+

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "db:migrate": "node db/migrate-fts.js",
+    "db:migrate:rebuild": "node db/migrate-fts.js --rebuild"
+  },
   "dependencies": {
     "discord-api-types": "^0.38.22",
     "discord.js": "^14.15.3",


### PR DESCRIPTION
## Summary
- rewrite `db/migrate-fts.js` to introspect verse columns and build `verses_fts` indexes for `asvs.sqlite` and `kjv_strongs.sqlite`
- add npm scripts to run the migration and optional rebuild

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run db:migrate:rebuild`


------
https://chatgpt.com/codex/tasks/task_e_68b3a087f5e48324aef928372bd98f9a