### PR TITLE
Use translations adapter for daily verse

### DIFF
--- a/src/db/translations.js
+++ b/src/db/translations.js
@@ -86,6 +86,10 @@ function getVerse(state, book, chapter, verse) {
 
 function search(state, query, limit = 10) {
   const c = state.columns;
+  if (query === 'random') {
+    const sql = `SELECT ${c.book} AS book, ${c.chapter} AS chapter, ${c.verse} AS verse, ${c.text} AS text FROM verses ORDER BY RANDOM() LIMIT ?`;
+    return all(state.db, sql, [limit]);
+  }
   if (state.hasFts) {
     const sql = `SELECT v.${c.book} AS book, v.${c.chapter} AS chapter, v.${c.verse} AS verse, snippet(verses_fts, 0, '<b>', '</b>', '...', 10) AS snippet FROM verses_fts JOIN verses v ON verses_fts.rowid = v.${c.id} WHERE verses_fts MATCH ? LIMIT ?`;
     return all(state.db, sql, [query, limit]);

--- a/test/translations.test.js
+++ b/test/translations.test.js
@@ -18,3 +18,11 @@ test('search finds verse', async () => {
   assert.ok(results.some(r => r.book === john && r.chapter === 3 && r.verse === 16));
   db.close();
 });
+
+test('random search returns a verse', async () => {
+  const db = await createAdapter('kjv_strongs');
+  const results = await db.search('random', 1);
+  assert.equal(results.length, 1);
+  assert.ok(results[0].text && results[0].book);
+  db.close();
+});


### PR DESCRIPTION
## Summary
- switch daily verse scheduler to use `createAdapter` and pick random verses
- add support for random queries in translation search
- test random verse lookup

## Testing
- `npm test` (fails: Missing script: "test")
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b3a121a938832481e1e5e241849702