### PR TITLE
feat: add FTS query sanitizer

### DIFF
--- a/src/utils/fts.js
+++ b/src/utils/fts.js
@@ -1,0 +1,20 @@
+const RESERVED = ['AND', 'OR', 'NOT', 'NEAR'];
+const SYNTAX_RE = /["*:^~]/;
+
+function quoteToken(token) {
+  if (!token) return '';
+  const needsQuote = SYNTAX_RE.test(token) || RESERVED.includes(token.toUpperCase());
+  if (!needsQuote) return token;
+  return '"' + token.replace(/"/g, '""') + '"';
+}
+
+function ftsSafeQuery(query = '') {
+  return query
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(quoteToken)
+    .join(' ');
+}
+
+module.exports = { ftsSafeQuery };

--- a/test/fts.test.js
+++ b/test/fts.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { ftsSafeQuery } = require('../src/utils/fts');
+
+test('wraps tokens containing special characters', () => {
+  assert.equal(ftsSafeQuery('jesus* love'), '"jesus*" love');
+});
+
+test('wraps reserved keywords', () => {
+  assert.equal(ftsSafeQuery('love AND faith'), 'love "AND" faith');
+});
+
+test('escapes quotes inside tokens', () => {
+  assert.equal(ftsSafeQuery('he"s'), '"he""s"');
+});


### PR DESCRIPTION
## Summary
- add FTS utility to quote tokens with SQLite FTS syntax characters
- test sanitizing queries and reserved words

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ad4ef8e88324ba40828572f11936