### PR TITLE
feat: add scripture reference parser

### DIFF
--- a/src/utils/refs.js
+++ b/src/utils/refs.js
@@ -1,0 +1,69 @@
+const { nameToId } = require('../lib/books');
+
+function parseRef(input = '') {
+  const str = String(input).trim();
+  if (!str) return null;
+
+  let bookId = null;
+  let rest = '';
+
+  // Numeric book IDs at the start
+  const numMatch = str.match(/^(\d+)\b\s*(.*)$/);
+  if (numMatch) {
+    const num = parseInt(numMatch[1], 10);
+    if (num >= 1 && num <= 66) {
+      bookId = num;
+      rest = numMatch[2].trim();
+    }
+  }
+
+  if (!bookId) {
+    const idx = str.search(/\d/);
+    let bookPart;
+    if (idx === -1) {
+      bookPart = str;
+      rest = '';
+    } else {
+      bookPart = str.slice(0, idx).trim();
+      rest = str.slice(idx).trim();
+    }
+    bookId = nameToId(bookPart);
+  }
+
+  if (!bookId) return null;
+  if (!rest) return { book: bookId };
+
+  const chapVerse = rest.match(/^(\d+)(?::(.*))?$/);
+  if (!chapVerse) return null;
+  const chapter = parseInt(chapVerse[1], 10);
+  if (!chapter) return null;
+
+  const versesPart = chapVerse[2];
+  if (!versesPart) {
+    // whole chapter
+    return { book: bookId, chapter };
+  }
+
+  const verses = [];
+  for (const segRaw of versesPart.split(/[,;]/)) {
+    const seg = segRaw.trim();
+    if (!seg) continue;
+    if (seg.includes('-')) {
+      const [startStr, endStr] = seg.split('-').map((s) => s.trim());
+      const start = parseInt(startStr, 10);
+      const end = parseInt(endStr, 10);
+      if (start && end && end >= start) {
+        for (let v = start; v <= end; v++) verses.push(v);
+      }
+    } else {
+      const v = parseInt(seg, 10);
+      if (v) verses.push(v);
+    }
+  }
+
+  if (verses.length === 0) return { book: bookId, chapter };
+  const unique = [...new Set(verses)].sort((a, b) => a - b);
+  return { book: bookId, chapter, verses: unique };
+}
+
+module.exports = { parseRef };

--- a/test/refs.test.js
+++ b/test/refs.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { parseRef } = require('../src/utils/refs');
+
+test('parses single verse', () => {
+  assert.deepEqual(parseRef('John 3:16'), { book: 43, chapter: 3, verses: [16] });
+});
+
+test('parses verse ranges', () => {
+  assert.deepEqual(parseRef('John 3:16-18'), { book: 43, chapter: 3, verses: [16, 17, 18] });
+});
+
+test('parses verse lists', () => {
+  assert.deepEqual(parseRef('John 3:16,18,20'), { book: 43, chapter: 3, verses: [16, 18, 20] });
+});
+
+test('parses whole chapter', () => {
+  assert.deepEqual(parseRef('John 3'), { book: 43, chapter: 3 });
+});
+
+test('handles numeric book ids', () => {
+  assert.deepEqual(parseRef('43 3:16'), { book: 43, chapter: 3, verses: [16] });
+});


### PR DESCRIPTION
## Summary
- add utility to parse scripture references with ranges and lists
- support numeric book identifiers
- cover reference parsing with tests

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b3afd6c82083248d03a3c8a8cc0563