### PR TITLE
Add chapter and verse range helpers

### DIFF
--- a/src/db/translations.js
+++ b/src/db/translations.js
@@ -18,6 +18,9 @@ function createAdapter(translation = 'asvs', options = {}) {
     .then(() => ensureFts(state, options.fts))
     .then(() => ({
       getVerse: (book, chapter, verse) => getVerse(state, book, chapter, verse),
+      getChapter: (book, chapter) => getChapter(state, book, chapter),
+      getVersesSubset: (book, chapter, start, end) =>
+        getVersesSubset(state, book, chapter, start, end),
       search: (q, limit) => search(state, q, limit),
       close: () => db.close(),
     }));
@@ -82,6 +85,18 @@ function getVerse(state, book, chapter, verse) {
       else resolve(row || null);
     });
   });
+}
+
+function getChapter(state, book, chapter) {
+  const c = state.columns;
+  const sql = `SELECT ${c.book} AS book, ${c.chapter} AS chapter, ${c.verse} AS verse, ${c.text} AS text FROM verses WHERE ${c.book}=? AND ${c.chapter}=? ORDER BY ${c.verse}`;
+  return all(state.db, sql, [book, chapter]);
+}
+
+function getVersesSubset(state, book, chapter, startVerse, endVerse) {
+  const c = state.columns;
+  const sql = `SELECT ${c.book} AS book, ${c.chapter} AS chapter, ${c.verse} AS verse, ${c.text} AS text FROM verses WHERE ${c.book}=? AND ${c.chapter}=? AND ${c.verse} BETWEEN ? AND ? ORDER BY ${c.verse}`;
+  return all(state.db, sql, [book, chapter, startVerse, endVerse]);
 }
 
 function search(state, query, limit = 10) {

--- a/test/translations.test.js
+++ b/test/translations.test.js
@@ -26,3 +26,21 @@ test('random search returns a verse', async () => {
   assert.ok(results[0].text && results[0].book);
   db.close();
 });
+
+test('getChapter retrieves all verses in order', async () => {
+  const db = await createAdapter('kjv_strongs');
+  const john = nameToId('John');
+  const verses = await db.getChapter(john, 3);
+  assert.ok(Array.isArray(verses) && verses.length > 0);
+  assert.equal(verses[0].verse, 1);
+  assert.ok(verses.every((v, i) => i === 0 || v.verse > verses[i - 1].verse));
+  db.close();
+});
+
+test('getVersesSubset retrieves range ordered by verse', async () => {
+  const db = await createAdapter('kjv_strongs');
+  const john = nameToId('John');
+  const verses = await db.getVersesSubset(john, 3, 16, 18);
+  assert.deepEqual(verses.map(v => v.verse), [16, 17, 18]);
+  db.close();
+});


### PR DESCRIPTION
## Summary
- add helper to load an entire chapter and expose it from translation adapter
- add helper to load a subset of verses within a chapter
- test chapter and verse range helpers

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b3b0fb44548324ac764288ed4c3966