### PR TITLE
feat: add smart search for scripture queries

### DIFF
--- a/SearchEngine.js
+++ b/SearchEngine.js
@@ -1,9 +1,10 @@
 const { createAdapter } = require('./src/db/translations');
+const searchSmart = require('./src/search/searchSmart');
 
 async function search(query, translation = 'asvs', limit = 10) {
   const adapter = await createAdapter(translation);
   try {
-    return await adapter.search(query, limit);
+    return await searchSmart(adapter, query, limit);
   } finally {
     if (adapter && adapter.close) adapter.close();
   }

--- a/scheduler/dailyVerseScheduler.js
+++ b/scheduler/dailyVerseScheduler.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const cron = require('node-cron');
 const { createAdapter } = require('../src/db/translations');
+const searchSmart = require('../src/search/searchSmart');
 const { idToName } = require('../src/lib/books');
 
 let currentDailyVerse = null;
@@ -23,7 +24,7 @@ function setupDailyVerse(client) {
       let adapter;
       try {
         adapter = await createAdapter(defaultTranslation);
-        const results = await adapter.search('random', 1);
+        const results = await searchSmart(adapter, 'random', 1);
         const row = results[0];
         if (!row) return;
 

--- a/src/search/searchSmart.js
+++ b/src/search/searchSmart.js
@@ -1,0 +1,41 @@
+const { parseRef } = require('../utils/refs');
+const { ftsSafeQuery } = require('../utils/fts');
+
+/**
+ * Perform a smart search over the scriptures. If the query is a reference,
+ * verses are fetched directly using adapter helpers. Otherwise an FTS query
+ * is executed through the adapter.
+ *
+ * @param {object} adapter Database adapter returned by createAdapter.
+ * @param {string} rawQuery The user provided search string.
+ * @param {number} [limit=10] Maximum number of results to return for text search.
+ * @returns {Promise<Array>} Array of verse rows.
+ */
+async function searchSmart(adapter, rawQuery, limit = 10) {
+  const query = String(rawQuery || '').trim();
+  if (!query) return [];
+
+  const ref = parseRef(query);
+  if (ref) {
+    const { book, chapter, verses } = ref;
+    if (book && chapter) {
+      if (Array.isArray(verses) && verses.length) {
+        if (verses.length === 1) {
+          const row = await adapter.getVerse(book, chapter, verses[0]);
+          return row ? [row] : [];
+        }
+        const start = Math.min(...verses);
+        const end = Math.max(...verses);
+        const subset = await adapter.getVersesSubset(book, chapter, start, end);
+        return subset.filter((r) => verses.includes(r.verse));
+      }
+      return adapter.getChapter(book, chapter);
+    }
+  }
+
+  const safe = ftsSafeQuery(query);
+  if (!safe) return [];
+  return adapter.search(safe, limit);
+}
+
+module.exports = searchSmart;


### PR DESCRIPTION
## Summary
- implement `searchSmart` to parse verse references and fall back to full-text search
- switch search logic to use `searchSmart` in search engine and daily verse scheduler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b3b296ea8c8324a0864e46f4d5e790