### PR TITLE
Add ASV and KJV translation support

### DIFF
--- a/SearchEngine.js
+++ b/SearchEngine.js
@@ -1,7 +1,7 @@
 const { createAdapter } = require('./src/db/translations');
 const searchSmart = require('./src/search/searchSmart');
 
-async function search(query, translation = 'asvs', limit = 10) {
+async function search(query, translation = 'asv', limit = 10) {
   const adapter = await createAdapter(translation);
   try {
     return await searchSmart(adapter, query, limit);

--- a/commands/brsearch.js
+++ b/commands/brsearch.js
@@ -18,8 +18,8 @@ module.exports = {
         .setName('translation')
         .setDescription('Bible translation')
         .addChoices(
-          { name: 'ASV', value: 'asvs' },
-          { name: 'KJV Strongs', value: 'kjv_strongs' }
+          { name: 'ASV', value: 'asv' },
+          { name: 'KJV', value: 'kjv' }
         )
     ),
 
@@ -27,7 +27,7 @@ module.exports = {
     const query = interaction.options.getString('query');
     let translation = interaction.options.getString('translation');
     if (!translation) {
-      translation = (await getUserTranslation(interaction.user.id)) || 'asvs';
+      translation = (await getUserTranslation(interaction.user.id)) || 'asv';
     }
 
     await interaction.deferReply();

--- a/db/migrate-fts.js
+++ b/db/migrate-fts.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 
 // Databases to process
-const dbFiles = ['asvs.sqlite', 'kjv_strongs.sqlite'];
+const dbFiles = ['asv.sqlite', 'asvs.sqlite', 'kjv.sqlite', 'kjv_strongs.sqlite'];
 
 // Optionally rebuild the FTS index contents
 const rebuild = process.argv.includes('--rebuild');

--- a/docs/database.md
+++ b/docs/database.md
@@ -6,8 +6,10 @@ This project uses SQLite databases to store Bible text and user preferences. Eac
 
 | File | Content table | FTS5 table |
 | --- | --- | --- |
-| `kjv_strongs.sqlite` | `verses` | `verses_fts` |
+| `asv.sqlite`         | `verses` | `verses_fts` |
 | `asvs.sqlite`        | `verses` | `verses_fts` |
+| `kjv.sqlite`         | `verses` | `verses_fts` |
+| `kjv_strongs.sqlite` | `verses` | `verses_fts` |
 
 ### `verses` schema
 
@@ -30,7 +32,7 @@ Per-user translation choices are stored in `db/bot_settings.sqlite`:
 ```sql
 CREATE TABLE user_prefs (
   user_id TEXT PRIMARY KEY,
-  translation TEXT CHECK(translation IN ('asvs','kjv_strongs')),
+  translation TEXT CHECK(translation IN ('asv','asvs','kjv','kjv_strongs')),
   updated_at INTEGER
 );
 ```

--- a/scheduler/dailyVerseScheduler.js
+++ b/scheduler/dailyVerseScheduler.js
@@ -14,7 +14,7 @@ function setupDailyVerse(client) {
   const { time, timezone, channelId, translation: configTranslation } = config;
 
   const defaultTranslation =
-    configTranslation || process.env.DEFAULT_TRANSLATION || 'asvs';
+    configTranslation || process.env.DEFAULT_TRANSLATION || 'asv';
 
   const [hour, minute] = time.split(':').map((num) => parseInt(num, 10));
 

--- a/src/commands/brtranslation.js
+++ b/src/commands/brtranslation.js
@@ -11,15 +11,15 @@ module.exports = {
         .setDescription('Translation to use')
         .setRequired(true)
         .addChoices(
-          { name: 'ASV', value: 'asvs' },
-          { name: 'KJV Strongs', value: 'kjv_strongs' }
+          { name: 'ASV', value: 'asv' },
+          { name: 'KJV', value: 'kjv' }
         )
     ),
   async execute(interaction) {
     const translation = interaction.options.getString('set');
     try {
       await setUserTranslation(interaction.user.id, translation);
-      const pretty = translation === 'asvs' ? 'ASV' : 'KJV Strongs';
+      const pretty = translation === 'asv' ? 'ASV' : 'KJV';
       await interaction.reply({
         content: `Translation set to ${pretty}.`,
         ephemeral: true,

--- a/src/commands/brverse.js
+++ b/src/commands/brverse.js
@@ -30,8 +30,8 @@ module.exports = {
         .setName('translation')
         .setDescription('Bible translation')
         .addChoices(
-          { name: 'ASV', value: 'asvs' },
-          { name: 'KJV Strongs', value: 'kjv_strongs' }
+          { name: 'ASV', value: 'asv' },
+          { name: 'KJV', value: 'kjv' }
         )
     ),
 
@@ -42,7 +42,7 @@ module.exports = {
     let translation = interaction.options.getString('translation');
 
     if (!translation) {
-      translation = (await getUserTranslation(interaction.user.id)) || 'asvs';
+      translation = (await getUserTranslation(interaction.user.id)) || 'asv';
     }
 
     const bookId = nameToId(bookInput);

--- a/src/db/translations.js
+++ b/src/db/translations.js
@@ -5,9 +5,11 @@ const sqlite3 = require('sqlite3').verbose();
 const FILES = {
   kjv_strongs: 'kjv_strongs.sqlite',
   asvs: 'asvs.sqlite',
+  asv: 'asv.sqlite',
+  kjv: 'kjv.sqlite',
 };
 
-function createAdapter(translation = 'asvs', options = {}) {
+function createAdapter(translation = 'asv', options = {}) {
   const file = FILES[translation.toLowerCase()];
   if (!file) throw new Error(`Unknown translation: ${translation}`);
   const dbPath = path.join(__dirname, '..', '..', 'db', file);

--- a/src/db/user-prefs.js
+++ b/src/db/user-prefs.js
@@ -7,7 +7,7 @@ const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READWRITE | sqlite3.OPEN_CR
 db.serialize(() => {
   db.run(`CREATE TABLE IF NOT EXISTS user_prefs (
     user_id TEXT PRIMARY KEY,
-    translation TEXT CHECK(translation IN ('asvs','kjv_strongs')),
+    translation TEXT CHECK(translation IN ('asv','asvs','kjv','kjv_strongs')),
     updated_at INTEGER
   )`);
 });

--- a/test/translations.test.js
+++ b/test/translations.test.js
@@ -4,7 +4,7 @@ const { createAdapter } = require('../src/db/translations');
 const { nameToId } = require('../src/lib/books');
 
 test('getVerse retrieves verse', async () => {
-  const db = await createAdapter('kjv_strongs');
+  const db = await createAdapter('kjv');
   const john = nameToId('John');
   const verse = await db.getVerse(john, 3, 16);
   assert.ok(verse && verse.text.includes('God'));
@@ -12,7 +12,7 @@ test('getVerse retrieves verse', async () => {
 });
 
 test('search finds verse', async () => {
-  const db = await createAdapter('kjv_strongs');
+  const db = await createAdapter('kjv');
   const results = await db.search('only begotten', 10);
   const john = nameToId('John');
   assert.ok(results.some(r => r.book === john && r.chapter === 3 && r.verse === 16));
@@ -20,7 +20,7 @@ test('search finds verse', async () => {
 });
 
 test('random search returns a verse', async () => {
-  const db = await createAdapter('kjv_strongs');
+  const db = await createAdapter('kjv');
   const results = await db.search('random', 1);
   assert.equal(results.length, 1);
   assert.ok(results[0].text && results[0].book);
@@ -28,7 +28,7 @@ test('random search returns a verse', async () => {
 });
 
 test('getChapter retrieves all verses in order', async () => {
-  const db = await createAdapter('kjv_strongs');
+  const db = await createAdapter('kjv');
   const john = nameToId('John');
   const verses = await db.getChapter(john, 3);
   assert.ok(Array.isArray(verses) && verses.length > 0);
@@ -38,9 +38,17 @@ test('getChapter retrieves all verses in order', async () => {
 });
 
 test('getVersesSubset retrieves range ordered by verse', async () => {
-  const db = await createAdapter('kjv_strongs');
+  const db = await createAdapter('kjv');
   const john = nameToId('John');
   const verses = await db.getVersesSubset(john, 3, 16, 18);
   assert.deepEqual(verses.map(v => v.verse), [16, 17, 18]);
+  db.close();
+});
+
+test('asv translation is supported', async () => {
+  const db = await createAdapter('asv');
+  const john = nameToId('John');
+  const verse = await db.getVerse(john, 3, 16);
+  assert.ok(verse && verse.text.includes('God'));
   db.close();
 });


### PR DESCRIPTION
## Summary
- include `asv` and `kjv` in translation database map and switch defaults to ASV
- expose ASV/KJV options in commands and user preferences
- document and test new translation support

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c07ed3708324bafb73e00243a6e1