### PR TITLE
feat: add openReading helper for translations

### DIFF
--- a/SearchEngine.js
+++ b/SearchEngine.js
@@ -1,8 +1,8 @@
-const { createAdapter } = require('./src/db/translations');
+const { openReading } = require('./src/db/openReading');
 const searchSmart = require('./src/search/searchSmart');
 
 async function search(query, translation = 'asv', limit = 10) {
-  const adapter = await createAdapter(translation);
+  const adapter = await openReading(translation);
   try {
     return await searchSmart(adapter, query, limit);
   } finally {

--- a/scheduler/dailyVerseScheduler.js
+++ b/scheduler/dailyVerseScheduler.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const cron = require('node-cron');
-const { createAdapter } = require('../src/db/translations');
+const { openReading } = require('../src/db/openReading');
 const searchSmart = require('../src/search/searchSmart');
 const { idToName } = require('../src/lib/books');
 
@@ -23,7 +23,7 @@ function setupDailyVerse(client) {
     async function () {
       let adapter;
       try {
-        adapter = await createAdapter(defaultTranslation);
+        adapter = await openReading(defaultTranslation);
         const results = await searchSmart(adapter, 'random', 1);
         const row = results[0];
         if (!row) return;

--- a/src/commands/brverse.js
+++ b/src/commands/brverse.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { nameToId, idToName } = require('../lib/books');
-const { createAdapter } = require('../db/translations');
+const { openReading } = require('../db/openReading');
 const { getUserTranslation } = require('../db/users');
 
 module.exports = {
@@ -53,7 +53,7 @@ module.exports = {
 
     let adapter;
     try {
-      adapter = await createAdapter(translation);
+      adapter = await openReading(translation);
       const result = await adapter.getVerse(bookId, chapter, verseNum);
       if (!result) {
         await interaction.reply('Verse not found.');

--- a/src/db/openReading.js
+++ b/src/db/openReading.js
@@ -1,0 +1,46 @@
+const { createAdapter } = require('./translations');
+
+const STRONGS_FALLBACK = {
+  kjv: 'kjv_strongs',
+  asv: 'asvs',
+};
+
+function stripStrongs(text) {
+  return text ? text.replace(/<[GH]\d+>/gi, '') : text;
+}
+
+async function openReading(translation = 'asv', options = {}) {
+  try {
+    return await createAdapter(translation, options);
+  } catch (err) {
+    const strongs = STRONGS_FALLBACK[translation];
+    if (!strongs) throw err;
+    const adapter = await createAdapter(strongs, options);
+    return {
+      getVerse: async (book, chapter, verse) => {
+        const row = await adapter.getVerse(book, chapter, verse);
+        if (row) row.text = stripStrongs(row.text);
+        return row;
+      },
+      getChapter: async (book, chapter) => {
+        const rows = await adapter.getChapter(book, chapter);
+        return rows.map((r) => ({ ...r, text: stripStrongs(r.text) }));
+      },
+      getVersesSubset: async (book, chapter, start, end) => {
+        const rows = await adapter.getVersesSubset(book, chapter, start, end);
+        return rows.map((r) => ({ ...r, text: stripStrongs(r.text) }));
+      },
+      search: async (q, limit) => {
+        const rows = await adapter.search(q, limit);
+        return rows.map((r) => {
+          if (r.snippet) return { ...r, snippet: stripStrongs(r.snippet) };
+          if (r.text) return { ...r, text: stripStrongs(r.text) };
+          return r;
+        });
+      },
+      close: () => adapter.close(),
+    };
+  }
+}
+
+module.exports = { openReading };


### PR DESCRIPTION
## Summary
- add openReading helper to use plain translations before falling back to Strong's databases
- refactor verse command, search engine, and daily verse scheduler to use openReading

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c285366c83249e0ead6e84c75c95