### PR TITLE
Limit brsearch output to Discord's message cap

### DIFF
--- a/commands/brsearch.js
+++ b/commands/brsearch.js
@@ -37,8 +37,38 @@ module.exports = {
         await interaction.editReply('No results found.');
         return;
       }
-      const lines = results.map(r => `${idToName(r.book)} ${r.chapter}:${r.verse} - ${r.snippet || r.text}`);
-      await interaction.editReply(lines.join('\n'));
+
+      const lines = results.map(
+        (r) => `${idToName(r.book)} ${r.chapter}:${r.verse} - ${r.snippet || r.text}`
+      );
+
+      const limit = 2000;
+      const marker = '[results truncated]';
+      const buffer = [];
+      let currentLength = 0;
+      let truncated = false;
+      for (const line of lines) {
+        const addition = (buffer.length ? 1 : 0) + line.length;
+        if (currentLength + addition > limit) {
+          truncated = true;
+          break;
+        }
+        buffer.push(line);
+        currentLength += addition;
+      }
+
+      let output = buffer.join('\n');
+      if (truncated) {
+        const markerAddition = (output.length ? 1 : 0) + marker.length;
+        while (output.length + markerAddition > limit && buffer.length) {
+          buffer.pop();
+          output = buffer.join('\n');
+        }
+        if (output.length) output += '\n';
+        output += marker;
+      }
+
+      await interaction.editReply(output);
     } catch (err) {
       console.error('Error performing search:', err);
       await interaction.editReply('There was an error executing this command.');

--- a/test/brsearch.test.js
+++ b/test/brsearch.test.js
@@ -1,0 +1,40 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+test('brsearch truncates long results with notice', async () => {
+  const searchModulePath = path.resolve(__dirname, '../SearchEngine.js');
+
+  const longText = 'x'.repeat(500);
+  const fakeResults = Array.from({ length: 10 }, (_, i) => ({
+    book: 1,
+    chapter: 1,
+    verse: i + 1,
+    text: longText,
+  }));
+
+  require.cache[searchModulePath] = {
+    exports: async () => fakeResults,
+  };
+
+  const brsearch = require('../commands/brsearch.js');
+
+  let reply = '';
+  const interaction = {
+    options: {
+      getString: (name) => (name === 'query' ? 'dummy' : name === 'translation' ? 'asv' : null),
+    },
+    user: { id: 'user' },
+    deferReply: () => Promise.resolve(),
+    editReply: (msg) => {
+      reply = msg;
+      return Promise.resolve();
+    },
+  };
+
+  await brsearch.execute(interaction);
+
+  assert.ok(reply.endsWith('[results truncated]'));
+  assert.ok(reply.length <= 2000);
+});
+


### PR DESCRIPTION
## Summary
- Stop `brsearch` from sending messages over 2000 chars
- Add truncation notice when results exceed the limit
- Test truncation behavior when search output is long

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c46cb66083249a8b2064054846f6