### PR TITLE
Normalize translation codes in user preferences

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -32,7 +32,7 @@ Per-user translation choices are stored in `db/bot_settings.sqlite`:
 ```sql
 CREATE TABLE user_prefs (
   user_id TEXT PRIMARY KEY,
-  translation TEXT CHECK(translation IN ('asv','asvs','kjv','kjv_strongs')),
+  translation TEXT CHECK(translation IN ('asv','kjv')),
   updated_at INTEGER
 );
 ```

--- a/src/db/user-prefs.js
+++ b/src/db/user-prefs.js
@@ -7,27 +7,40 @@ const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READWRITE | sqlite3.OPEN_CR
 db.serialize(() => {
   db.run(`CREATE TABLE IF NOT EXISTS user_prefs (
     user_id TEXT PRIMARY KEY,
-    translation TEXT CHECK(translation IN ('asv','asvs','kjv','kjv_strongs')),
+    translation TEXT CHECK(translation IN ('asv','kjv')),
     updated_at INTEGER
   )`);
+
+  // One-time migration to normalize legacy translation values
+  db.run(
+    "UPDATE user_prefs SET translation = CASE translation WHEN 'asvs' THEN 'asv' WHEN 'kjv_strongs' THEN 'kjv' ELSE translation END WHERE translation IN ('asvs','kjv_strongs')"
+  );
 });
+
+function normalizeTranslation(t) {
+  if (!t) return t;
+  if (t === 'asvs') return 'asv';
+  if (t === 'kjv_strongs') return 'kjv';
+  return t;
+}
 
 function getUserTranslation(userId) {
   return new Promise((resolve, reject) => {
     db.get('SELECT translation FROM user_prefs WHERE user_id = ?', [userId], (err, row) => {
       if (err) reject(err);
-      else resolve(row ? row.translation : null);
+      else resolve(row ? normalizeTranslation(row.translation) : null);
     });
   });
 }
 
 function setUserTranslation(userId, translation) {
   const now = Date.now();
+  const normalized = normalizeTranslation(translation);
   return new Promise((resolve, reject) => {
     const sql = `INSERT INTO user_prefs (user_id, translation, updated_at)
                  VALUES (?, ?, ?)
                  ON CONFLICT(user_id) DO UPDATE SET translation=excluded.translation, updated_at=excluded.updated_at`;
-    db.run(sql, [userId, translation, now], (err) => {
+    db.run(sql, [userId, normalized, now], (err) => {
       if (err) reject(err);
       else resolve();
     });


### PR DESCRIPTION
## Summary
- Restrict `user_prefs` table to `asv` and `kjv` translations.
- Normalize legacy values (`asvs`, `kjv_strongs`) and migrate existing records.
- Document updated `user_prefs` schema.

## Testing
- `npm test` *(fails: Missing script "test")*
- `node` manual check of normalization and migration

------
https://chatgpt.com/codex/tasks/task_e_68b3c52b374483249bf71fef12af2058