### PR TITLE
Support non-contiguous verse subsets

### DIFF
--- a/src/db/openReading.js
+++ b/src/db/openReading.js
@@ -26,8 +26,8 @@ async function openReading(translation = 'asv', options = {}) {
         const rows = await adapter.getChapter(book, chapter);
         return rows.map((r) => ({ ...r, text: stripStrongs(r.text) }));
       },
-      getVersesSubset: async (book, chapter, start, end) => {
-        const rows = await adapter.getVersesSubset(book, chapter, start, end);
+      getVersesSubset: async (book, chapter, verses) => {
+        const rows = await adapter.getVersesSubset(book, chapter, verses);
         return rows.map((r) => ({ ...r, text: stripStrongs(r.text) }));
       },
       search: async (q, limit) => {

--- a/src/search/searchSmart.js
+++ b/src/search/searchSmart.js
@@ -24,10 +24,7 @@ async function searchSmart(adapter, rawQuery, limit = 10) {
           const row = await adapter.getVerse(book, chapter, verses[0]);
           return row ? [row] : [];
         }
-        const start = Math.min(...verses);
-        const end = Math.max(...verses);
-        const subset = await adapter.getVersesSubset(book, chapter, start, end);
-        return subset.filter((r) => verses.includes(r.verse));
+        return adapter.getVersesSubset(book, chapter, verses);
       }
       return adapter.getChapter(book, chapter);
     }

--- a/test/searchSmart.test.js
+++ b/test/searchSmart.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const searchSmart = require('../src/search/searchSmart');
+const { createAdapter } = require('../src/db/translations');
+const { nameToId } = require('../src/lib/books');
+
+test('searchSmart handles non-contiguous verse lists', async () => {
+  const adapter = await createAdapter('kjv');
+  const john = nameToId('John');
+  const results = await searchSmart(adapter, 'John 3:16,18');
+  assert.deepEqual(results.map(r => r.verse), [16, 18]);
+  assert.ok(results.every(r => r.book === john && r.chapter === 3));
+  adapter.close();
+});

--- a/test/translations.test.js
+++ b/test/translations.test.js
@@ -37,11 +37,11 @@ test('getChapter retrieves all verses in order', async () => {
   db.close();
 });
 
-test('getVersesSubset retrieves range ordered by verse', async () => {
+test('getVersesSubset retrieves non-contiguous verses ordered by verse', async () => {
   const db = await createAdapter('kjv');
   const john = nameToId('John');
-  const verses = await db.getVersesSubset(john, 3, 16, 18);
-  assert.deepEqual(verses.map(v => v.verse), [16, 17, 18]);
+  const verses = await db.getVersesSubset(john, 3, [16, 18]);
+  assert.deepEqual(verses.map(v => v.verse), [16, 18]);
   db.close();
 });
 


### PR DESCRIPTION
## Summary
- Allow adapter `getVersesSubset` to accept an array of verses and query using an SQL `IN` clause
- Pass the verse array directly in `searchSmart` and update `openReading`
- Add tests for non-contiguous verse lists

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c61258d48324a25265547b76481d