### PR TITLE
Enhance brverse command with autocomplete and context buttons

### DIFF
--- a/src/commands/brverse.js
+++ b/src/commands/brverse.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
-const { nameToId, idToName } = require('../lib/books');
-const { openReading } = require('../db/openReading');
+const { nameToId, idToName, searchBooks } = require('../lib/books');
+const { openReadingAdapter } = require('../db/openReading');
+const contextRow = require('../ui/contextRow');
 const { getUserTranslation } = require('../db/users');
 
 module.exports = {
@@ -12,18 +13,21 @@ module.exports = {
         .setName('book')
         .setDescription('Book of the Bible')
         .setRequired(true)
+        .setAutocomplete(true)
     )
     .addIntegerOption(option =>
       option
         .setName('chapter')
         .setDescription('Chapter number')
         .setRequired(true)
+        .setAutocomplete(true)
     )
     .addIntegerOption(option =>
       option
         .setName('verse')
         .setDescription('Verse number')
         .setRequired(true)
+        .setAutocomplete(true)
     )
     .addStringOption(option =>
       option
@@ -36,7 +40,7 @@ module.exports = {
     ),
 
   async execute(interaction) {
-    const bookInput = interaction.options.getString('book');
+    const bookArg = interaction.options.getString('book');
     const chapter = interaction.options.getInteger('chapter');
     const verseNum = interaction.options.getInteger('verse');
     let translation = interaction.options.getString('translation');
@@ -45,28 +49,58 @@ module.exports = {
       translation = (await getUserTranslation(interaction.user.id)) || 'asv';
     }
 
-    const bookId = nameToId(bookInput);
+    let bookId = Number(bookArg);
+    if (Number.isNaN(bookId)) {
+      bookId = nameToId(bookArg);
+    }
     if (!bookId) {
-      await interaction.reply('Unknown book.');
+      await interaction.reply({ content: 'Unknown book.', ephemeral: true });
       return;
     }
 
     let adapter;
     try {
-      adapter = await openReading(translation);
+      adapter = await openReadingAdapter(translation);
       const result = await adapter.getVerse(bookId, chapter, verseNum);
       if (!result) {
         await interaction.reply('Verse not found.');
       } else {
         const bookName = idToName(result.book);
         const message = `${bookName} ${result.chapter}:${result.verse} - ${result.text}`;
-        await interaction.reply(message);
+        const components = contextRow.build({
+          book: result.book,
+          chapter: result.chapter,
+          verse: result.verse,
+          translation,
+        });
+        await interaction.reply({ content: message, components });
       }
     } catch (err) {
       console.error('Error fetching verse:', err);
       await interaction.reply('There was an error fetching the verse.');
     } finally {
       if (adapter && adapter.close) adapter.close();
+    }
+  },
+  async autocomplete(interaction) {
+    const focused = interaction.options.getFocused(true);
+    const value = focused.value;
+    if (focused.name === 'book') {
+      const choices = searchBooks(value).map(({ id, name }) => ({
+        name,
+        value: String(id),
+      }));
+      await interaction.respond(choices);
+    } else if (focused.name === 'chapter' || focused.name === 'verse') {
+      const num = parseInt(value, 10);
+      const start = Number.isNaN(num) || num < 1 ? 1 : num;
+      const options = Array.from({ length: 25 }, (_, i) => start + i).map((n) => ({
+        name: String(n),
+        value: n,
+      }));
+      await interaction.respond(options);
+    } else {
+      await interaction.respond([]);
     }
   },
 };

--- a/src/db/openReading.js
+++ b/src/db/openReading.js
@@ -43,4 +43,4 @@ async function openReading(translation = 'asv', options = {}) {
   }
 }
 
-module.exports = { openReading };
+module.exports = { openReading, openReadingAdapter: openReading };

--- a/src/ui/contextRow.js
+++ b/src/ui/contextRow.js
@@ -1,0 +1,12 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+function build({ translation, book, chapter, verse }) {
+  const customId = `context:${translation}:${book}:${chapter}:${verse}`;
+  const button = new ButtonBuilder()
+    .setCustomId(customId)
+    .setLabel('Context')
+    .setStyle(ButtonStyle.Secondary);
+  return [new ActionRowBuilder().addComponents(button)];
+}
+
+module.exports = { build };


### PR DESCRIPTION
## Summary
- enable autocomplete for book, chapter, and verse options
- resolve book input flexibly and attach context buttons
- add openReadingAdapter alias and contextRow helper

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b47ea9a23483248edcdc39e0ef1acc