### PR TITLE
Add centralized autocomplete handler for verse inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const { Client, Collection, GatewayIntentBits } = require("discord.js");
 const { setupDailyVerse } = require("./scheduler/dailyVerseScheduler"); // Correct import
+const handleAutocomplete = require("./src/interaction/autocomplete");
 
 const client = new Client({
   intents: [
@@ -62,6 +63,14 @@ client.once("ready", () => {
 });
 
 client.on("interactionCreate", async (interaction) => {
+  if (interaction.isAutocomplete()) {
+    try {
+      await handleAutocomplete(interaction);
+    } catch (error) {
+      console.error("Error executing autocomplete handler:", error);
+    }
+    return;
+  }
   if (interaction.isChatInputCommand()) {
     const command = client.commands.get(interaction.commandName);
     if (!command) {
@@ -79,21 +88,6 @@ client.on("interactionCreate", async (interaction) => {
         content: "There was an error while executing this command!",
         ephemeral: true,
       });
-    }
-  } else if (interaction.isAutocomplete()) {
-    const command = client.commands.get(interaction.commandName);
-    if (!command || !command.autocomplete) {
-      try {
-        await interaction.respond([]);
-      } catch (err) {
-        console.error("Error responding to unknown autocomplete:", err);
-      }
-      return;
-    }
-    try {
-      await command.autocomplete(interaction);
-    } catch (error) {
-      console.error("Error executing autocomplete handler:", error);
     }
   } else if (interaction.isButton()) {
     const handler = client.buttons.get(interaction.customId);

--- a/src/commands/brverse.js
+++ b/src/commands/brverse.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
-const { nameToId, idToName, searchBooks } = require('../lib/books');
+const { nameToId, idToName } = require('../lib/books');
 const { openReadingAdapter } = require('../db/openReading');
 const contextRow = require('../ui/contextRow');
 const { getUserTranslation } = require('../db/users');
@@ -80,27 +80,6 @@ module.exports = {
       await interaction.reply('There was an error fetching the verse.');
     } finally {
       if (adapter && adapter.close) adapter.close();
-    }
-  },
-  async autocomplete(interaction) {
-    const focused = interaction.options.getFocused(true);
-    const value = focused.value;
-    if (focused.name === 'book') {
-      const choices = searchBooks(value).map(({ id, name }) => ({
-        name,
-        value: String(id),
-      }));
-      await interaction.respond(choices);
-    } else if (focused.name === 'chapter' || focused.name === 'verse') {
-      const num = parseInt(value, 10);
-      const start = Number.isNaN(num) || num < 1 ? 1 : num;
-      const options = Array.from({ length: 25 }, (_, i) => start + i).map((n) => ({
-        name: String(n),
-        value: n,
-      }));
-      await interaction.respond(options);
-    } else {
-      await interaction.respond([]);
     }
   },
 };

--- a/src/db/openReading.js
+++ b/src/db/openReading.js
@@ -39,6 +39,8 @@ async function openReading(translation = 'asv', options = {}) {
         });
       },
       close: () => adapter.close(),
+      _db: adapter._db,
+      _cols: adapter._cols,
     };
   }
 }

--- a/src/db/translations.js
+++ b/src/db/translations.js
@@ -26,6 +26,8 @@ function createAdapter(translation = 'asv', options = {}) {
         getVersesSubset(state, book, chapter, verses),
       search: (q, limit) => search(state, q, limit),
       close: () => db.close(),
+      _db: state.db,
+      _cols: state.columns,
     }));
 }
 

--- a/src/interaction/autocomplete.js
+++ b/src/interaction/autocomplete.js
@@ -1,0 +1,95 @@
+const { searchBooks } = require('../lib/books');
+const { openReadingAdapter } = require('../db/openReading');
+const { getUserTranslation } = require('../db/users');
+
+async function getMaxChapter(adapter, bookId) {
+  const c = adapter._cols;
+  const sql = `SELECT MAX(${c.chapter}) AS max FROM verses WHERE ${c.book}=?`;
+  return new Promise((resolve, reject) => {
+    adapter._db.get(sql, [bookId], (err, row) => {
+      if (err) reject(err);
+      else resolve(row?.max || 0);
+    });
+  });
+}
+
+async function getMaxVerse(adapter, bookId, chapter) {
+  const c = adapter._cols;
+  const sql = `SELECT MAX(${c.verse}) AS max FROM verses WHERE ${c.book}=? AND ${c.chapter}=?`;
+  return new Promise((resolve, reject) => {
+    adapter._db.get(sql, [bookId, chapter], (err, row) => {
+      if (err) reject(err);
+      else resolve(row?.max || 0);
+    });
+  });
+}
+
+module.exports = async function handleAutocomplete(interaction) {
+  const focused = interaction.options.getFocused(true);
+  const value = focused.value;
+
+  if (focused.name === 'book') {
+    const choices = searchBooks(value).map(({ id, name }) => ({
+      name,
+      value: String(id),
+    }));
+    await interaction.respond(choices.slice(0, 25));
+    return;
+  }
+
+  let adapter;
+  try {
+    const bookVal = interaction.options.get('book')?.value;
+    const chapterVal = interaction.options.get('chapter')?.value;
+
+    if (focused.name === 'chapter') {
+      const bookId = Number(bookVal);
+      if (!bookId) return interaction.respond([]);
+
+      let translation = interaction.options.getString('translation');
+      if (!translation) {
+        translation = (await getUserTranslation(interaction.user.id)) || 'asv';
+      }
+      adapter = await openReadingAdapter(translation);
+
+      const max = await getMaxChapter(adapter, bookId);
+      const num = parseInt(value, 10);
+      const start = Number.isNaN(num) || num < 1 ? 1 : num;
+      const options = [];
+      for (let n = start; n <= max && options.length < 25; n++) {
+        options.push({ name: String(n), value: n });
+      }
+      await interaction.respond(options);
+    } else if (focused.name === 'verse') {
+      const bookId = Number(bookVal);
+      const chapter = Number(chapterVal);
+      if (!bookId || !chapter) return interaction.respond([]);
+
+      let translation = interaction.options.getString('translation');
+      if (!translation) {
+        translation = (await getUserTranslation(interaction.user.id)) || 'asv';
+      }
+      adapter = await openReadingAdapter(translation);
+
+      const max = await getMaxVerse(adapter, bookId, chapter);
+      const num = parseInt(value, 10);
+      const start = Number.isNaN(num) || num < 1 ? 1 : num;
+      const options = [];
+      for (let n = start; n <= max && options.length < 25; n++) {
+        options.push({ name: String(n), value: n });
+      }
+      await interaction.respond(options);
+    } else {
+      await interaction.respond([]);
+    }
+  } catch (err) {
+    console.error('Autocomplete error:', err);
+    try {
+      await interaction.respond([]);
+    } catch (e) {
+      console.error('Failed to respond to autocomplete error:', e);
+    }
+  } finally {
+    if (adapter && adapter.close) adapter.close();
+  }
+};


### PR DESCRIPTION
## Summary
- Add `src/interaction/autocomplete.js` to provide book/chapter/verse suggestions with database-backed limits
- Expose `_db` and `_cols` from reading adapters so callers can query max chapters and verses
- Handle autocomplete interactions globally in `index.js` and remove command-specific autocomplete logic

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4801fa27c8324b8c53f66110c3915