### PR TITLE
feat: add context button handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const path = require("path");
 const { Client, Collection, GatewayIntentBits } = require("discord.js");
 const { setupDailyVerse } = require("./scheduler/dailyVerseScheduler"); // Correct import
 const handleAutocomplete = require("./src/interaction/autocomplete");
+const handleContextButtons = require("./src/interaction/contextButtons");
 
 const client = new Client({
   intents: [
@@ -90,6 +91,8 @@ client.on("interactionCreate", async (interaction) => {
       });
     }
   } else if (interaction.isButton()) {
+    if (await handleContextButtons(interaction)) return;
+
     const handler = client.buttons.get(interaction.customId);
     if (!handler) {
       try {

--- a/src/interaction/contextButtons.js
+++ b/src/interaction/contextButtons.js
@@ -1,0 +1,113 @@
+const { openReadingAdapter } = require('../db/openReading');
+const { createAdapter } = require('../db/translations');
+const { idToName } = require('../lib/books');
+const { unpack } = require('../ui/contextRow');
+
+const STRONGS_TRANSLATIONS = {
+  kjv: 'kjv_strongs',
+  asv: 'asvs',
+  kjv_strongs: 'kjv_strongs',
+  asvs: 'asvs',
+};
+
+async function findXrefs(adapter, strong, exclude) {
+  const c = adapter._cols;
+  const sql = `SELECT ${c.book} AS book, ${c.chapter} AS chapter, ${c.verse} AS verse FROM verses WHERE ${c.text} LIKE ? LIMIT 5`;
+  return new Promise((resolve, reject) => {
+    adapter._db.all(sql, [`%<${strong}>%`], (err, rows) => {
+      if (err) return reject(err);
+      const refs = rows.filter(
+        (r) => !(r.book === exclude.book && r.chapter === exclude.chapter && r.verse === exclude.verse)
+      );
+      resolve(refs);
+    });
+  });
+}
+
+module.exports = async function handleContextButtons(interaction) {
+  const id = interaction.customId || '';
+  if (!id.startsWith('ctx:')) return false;
+
+  const [, action, payload] = id.split(':');
+  const data = unpack(payload);
+  if (!data) return false;
+
+  const { translation, book, chapter, verse } = data;
+
+  try {
+    if (action === 'more') {
+      const adapter = await openReadingAdapter(translation);
+      const verses = [verse - 1, verse, verse + 1].filter((v) => v > 0);
+      const rows = await adapter.getVersesSubset(book, chapter, verses);
+      adapter.close();
+      if (!rows.length) {
+        await interaction.reply({ content: 'No additional context available.', ephemeral: true });
+        return true;
+      }
+      const bookName = idToName(book);
+      const msg = rows
+        .map((r) => `${r.verse}. ${r.text}`)
+        .join('\n');
+      await interaction.reply({ content: `${bookName} ${chapter}\n${msg}`, ephemeral: true });
+      return true;
+    }
+
+    if (action === 'orig' || action === 'xref') {
+      const strongsTrans = STRONGS_TRANSLATIONS[translation] || translation;
+      const adapter = await createAdapter(strongsTrans);
+      const row = await adapter.getVerse(book, chapter, verse);
+      if (!row) {
+        adapter.close();
+        await interaction.reply({ content: 'Verse not found.', ephemeral: true });
+        return true;
+      }
+
+      if (action === 'orig') {
+        const bookName = idToName(book);
+        await interaction.reply({
+          content: `${bookName} ${chapter}:${verse} - ${row.text}`,
+          ephemeral: true,
+        });
+        adapter.close();
+        return true;
+      }
+
+      // xref
+      const matches = row.text.match(/<[GH]\d+>/gi) || [];
+      const unique = Array.from(new Set(matches.map((m) => m.slice(1, -1))));
+      const xrefs = [];
+      for (const strong of unique) {
+        const refs = await findXrefs(adapter, strong, { book, chapter, verse });
+        for (const r of refs) {
+          const refStr = `${idToName(r.book)} ${r.chapter}:${r.verse}`;
+          if (!xrefs.includes(refStr)) xrefs.push(refStr);
+          if (xrefs.length >= 5) break;
+        }
+        if (xrefs.length >= 5) break;
+      }
+      adapter.close();
+      if (!xrefs.length) {
+        await interaction.reply({ content: 'No cross references found.', ephemeral: true });
+      } else {
+        await interaction.reply({
+          content: `Cross references: ${xrefs.join(', ')}`,
+          ephemeral: true,
+        });
+      }
+      return true;
+    }
+  } catch (err) {
+    console.error('Error handling context button:', err);
+    if (!interaction.replied) {
+      try {
+        await interaction.reply({ content: 'Error processing request.', ephemeral: true });
+      } catch (e) {
+        console.error('Failed to reply to interaction:', e);
+      }
+    }
+    return true;
+  }
+
+  return false;
+};
+

--- a/src/ui/contextRow.js
+++ b/src/ui/contextRow.js
@@ -1,12 +1,35 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 
-function build({ translation, book, chapter, verse }) {
-  const customId = `context:${translation}:${book}:${chapter}:${verse}`;
-  const button = new ButtonBuilder()
-    .setCustomId(customId)
-    .setLabel('Context')
-    .setStyle(ButtonStyle.Secondary);
-  return [new ActionRowBuilder().addComponents(button)];
+function pack(data) {
+  const json = JSON.stringify(data);
+  return Buffer.from(json).toString('base64');
 }
 
-module.exports = { build };
+function unpack(payload) {
+  try {
+    const json = Buffer.from(payload, 'base64').toString('utf8');
+    return JSON.parse(json);
+  } catch (e) {
+    return null;
+  }
+}
+
+function build({ translation, book, chapter, verse }) {
+  const payload = pack({ translation, book, chapter, verse });
+  const more = new ButtonBuilder()
+    .setCustomId(`ctx:more:${payload}`)
+    .setLabel('More')
+    .setStyle(ButtonStyle.Secondary);
+  const orig = new ButtonBuilder()
+    .setCustomId(`ctx:orig:${payload}`)
+    .setLabel("Original")
+    .setStyle(ButtonStyle.Secondary);
+  const xref = new ButtonBuilder()
+    .setCustomId(`ctx:xref:${payload}`)
+    .setLabel('Cross Ref')
+    .setStyle(ButtonStyle.Secondary);
+  return [new ActionRowBuilder().addComponents(more, orig, xref)];
+}
+
+module.exports = { build, pack, unpack };
+


### PR DESCRIPTION
## Summary
- build context UI row with encoded payloads and actions for more context, original text, and cross references
- handle context button interactions using reading and Strong's adapters
- dispatch context button handler before fallback button collection

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4846336ec83248e9b6edc0ffe593f