### PR TITLE
feat: delegate context buttons before other handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,9 @@ client.on("interactionCreate", async (interaction) => {
       });
     }
   } else if (interaction.isButton()) {
-    if (await handleContextButtons(interaction)) return;
+    // Attempt to handle context-specific buttons before other handlers
+    const contextHandled = await handleContextButtons(interaction);
+    if (contextHandled) return;
 
     const handler = client.buttons.get(interaction.customId);
     if (!handler) {


### PR DESCRIPTION
## Summary
- handle context buttons before looking up other button handlers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4857df76c83248bbddc9faca17a3d