### PR TITLE
Handle lexicon buttons before other button handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const { Client, Collection, GatewayIntentBits } = require("discord.js");
 const { setupDailyVerse } = require("./scheduler/dailyVerseScheduler"); // Correct import
+const { handleButtons: handleLexButtons } = require("./src/commands/brlex");
 
 const client = new Client({
   intents: [
@@ -103,6 +104,7 @@ client.on("interactionCreate", async (interaction) => {
       console.error("Error executing autocomplete handler:", error);
     }
   } else if (interaction.isButton()) {
+    if (await handleLexButtons(interaction)) return;
     let handler = client.buttons.get(interaction.customId);
     if (!handler) {
       const dynamic = client.dynamicButtons.find((h) =>

--- a/src/commands/brlex.js
+++ b/src/commands/brlex.js
@@ -124,14 +124,14 @@ function lexEmbed(strong, entry, verses, offset, total) {
 
 async function handleButtons(interaction) {
   const [action, payload] = interaction.customId.split(":");
-  if (!action.startsWith("brlex_")) return;
+  if (!action.startsWith("brlex_")) return false;
   const state = unpackState(payload);
   if (!state || !state.strong) {
     await interaction.reply({
       content: "Invalid button state.",
       ephemeral: true,
     });
-    return;
+    return true;
   }
   const { strong, offset = 0 } = state;
   const entry = getLexEntry(strong);
@@ -155,6 +155,7 @@ async function handleButtons(interaction) {
   );
 
   await interaction.update({ embeds: [embed], components: [row] });
+  return true;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- Import lexicon button handler directly in `index.js`
- Invoke the lexicon handler prior to other button handlers
- Make lexicon button handler return a boolean when it processes an interaction

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b48efdde8c83248da998daf4f1d935