### PR TITLE
feat: schedule daily verses per guild

### DIFF
--- a/commands/brdaily.js
+++ b/commands/brdaily.js
@@ -1,14 +1,14 @@
 // commands/brdaily.js
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder } = require("discord.js");
-const { getCurrentDailyVerse } = require("../scheduler/dailyVerseScheduler");
+const { getCurrentDailyVerse, setupDailyVerse } = require("../scheduler/dailyVerseScheduler");
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName("brdaily")
     .setDescription("Receives the daily verse."),
   async execute(interaction) {
-    const currentDailyVerse = getCurrentDailyVerse();
+    const currentDailyVerse = getCurrentDailyVerse(interaction.guildId);
 
     if (currentDailyVerse) {
       const embed = new EmbedBuilder()
@@ -21,5 +21,8 @@ module.exports = {
     } else {
       await interaction.reply("No daily verse has been set yet.");
     }
+
+    // Reschedule tasks in case configuration has changed
+    await setupDailyVerse(interaction.client);
   },
 };

--- a/index.js
+++ b/index.js
@@ -64,9 +64,9 @@ if (fs.existsSync(buttonsPath)) {
   });
 }
 
-client.once("ready", () => {
+client.once("ready", async () => {
   console.log(`Logged in as ${client.user.tag}`);
-  setupDailyVerse(client); // Set up the daily verse scheduler when the client is ready
+  await setupDailyVerse(client); // Set up the daily verse scheduler when the client is ready
 });
 
 client.on("interactionCreate", async (interaction) => {

--- a/src/db/guild-settings.js
+++ b/src/db/guild-settings.js
@@ -1,0 +1,84 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const fs = require('fs');
+
+// Ensure the database directory exists
+const dbDir = path.join(__dirname, '..', '..', 'db');
+if (!fs.existsSync(dbDir)) {
+  fs.mkdirSync(dbDir, { recursive: true });
+}
+
+const dbPath = path.join(dbDir, 'bot_settings.sqlite');
+const db = new sqlite3.Database(dbPath);
+
+db.serialize(() => {
+  db.run(
+    `CREATE TABLE IF NOT EXISTS daily_settings (
+      guild_id TEXT PRIMARY KEY,
+      channel_id TEXT NOT NULL,
+      time TEXT NOT NULL,
+      timezone TEXT NOT NULL
+    )`
+  );
+});
+
+function getAllDailySettings() {
+  return new Promise((resolve, reject) => {
+    db.all(
+      'SELECT guild_id, channel_id, time, timezone FROM daily_settings',
+      (err, rows) => {
+        if (err) reject(err);
+        else resolve(rows || []);
+      }
+    );
+  });
+}
+
+function getDailySettings(guildId) {
+  return new Promise((resolve, reject) => {
+    db.get(
+      'SELECT guild_id, channel_id, time, timezone FROM daily_settings WHERE guild_id = ?',
+      [guildId],
+      (err, row) => {
+        if (err) reject(err);
+        else resolve(row);
+      }
+    );
+  });
+}
+
+function setDailySettings(guildId, channelId, time, timezone) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      `INSERT INTO daily_settings (guild_id, channel_id, time, timezone)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(guild_id) DO UPDATE SET channel_id = excluded.channel_id, time = excluded.time, timezone = excluded.timezone`,
+      [guildId, channelId, time, timezone],
+      function (err) {
+        if (err) reject(err);
+        else resolve();
+      }
+    );
+  });
+}
+
+function deleteDailySettings(guildId) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      'DELETE FROM daily_settings WHERE guild_id = ?',
+      [guildId],
+      function (err) {
+        if (err) reject(err);
+        else resolve();
+      }
+    );
+  });
+}
+
+module.exports = {
+  getAllDailySettings,
+  getDailySettings,
+  setDailySettings,
+  deleteDailySettings,
+};
+


### PR DESCRIPTION
## Summary
- add sqlite helper for per-guild daily verse settings
- schedule daily verses per guild and refresh tasks
- fetch daily verse per guild and reschedule on demand

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b4908b0cd48324925793483af46b9b