### PR TITLE
Add subcommands for managing daily verse schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To get started with this bot, you will need to have a hosting solution for Node.
     /brsearch Luke 1:1-3 or Luke - Retrieve all information matching search term.
     /brpoints - View the top 10 users points standings.
     /brmypoints - View your current points standings.
-    /brdaily - View the daily verse.
+    /brdaily set|status|clear - Manage daily verse settings.
     /brtrivia - Start a Bible trivia game, optionally specifying a category.
 
 ## Configuration:

--- a/commands/brdaily.js
+++ b/commands/brdaily.js
@@ -1,28 +1,91 @@
 // commands/brdaily.js
 const { SlashCommandBuilder } = require("@discordjs/builders");
-const { EmbedBuilder } = require("discord.js");
-const { getCurrentDailyVerse, setupDailyVerse } = require("../scheduler/dailyVerseScheduler");
+const moment = require("moment-timezone");
+const { setOne, getOne, clearOne } = require("../src/db/guild-settings");
+const { setupDailyVerse } = require("../scheduler/dailyVerseScheduler");
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName("brdaily")
-    .setDescription("Receives the daily verse."),
+    .setDescription("Manage daily verse settings.")
+    .addSubcommand((sub) =>
+      sub
+        .setName("set")
+        .setDescription("Set daily verse delivery.")
+        .addChannelOption((opt) =>
+          opt
+            .setName("channel")
+            .setDescription("Channel for the daily verse.")
+            .setRequired(true)
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName("time")
+            .setDescription("Time in HH:mm format.")
+            .setRequired(true)
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName("timezone")
+            .setDescription("Timezone, e.g. America/New_York.")
+            .setRequired(true)
+        )
+    )
+    .addSubcommand((sub) =>
+      sub.setName("status").setDescription("Show current daily verse settings."))
+    .addSubcommand((sub) =>
+      sub.setName("clear").setDescription("Clear daily verse settings.")),
   async execute(interaction) {
-    const currentDailyVerse = getCurrentDailyVerse(interaction.guildId);
+    const sub = interaction.options.getSubcommand();
+    if (sub === "set") {
+      const channel = interaction.options.getChannel("channel");
+      const time = interaction.options.getString("time");
+      const timezone = interaction.options.getString("timezone");
 
-    if (currentDailyVerse) {
-      const embed = new EmbedBuilder()
-        .setColor("#0099ff")
-        .setTitle("Today's Daily Verse")
-        .setDescription(currentDailyVerse)
-        .setTimestamp();
+      if (!moment(time, "HH:mm", true).isValid()) {
+        await interaction.reply({
+          content: "Invalid time. Use HH:mm (24-hour format).",
+          ephemeral: true,
+        });
+        return;
+      }
 
-      await interaction.reply({ embeds: [embed] });
-    } else {
-      await interaction.reply("No daily verse has been set yet.");
+      if (!moment.tz.zone(timezone)) {
+        await interaction.reply({
+          content: "Invalid timezone.",
+          ephemeral: true,
+        });
+        return;
+      }
+
+      await setOne(interaction.guildId, channel.id, time, timezone);
+      await setupDailyVerse(interaction.client);
+
+      await interaction.reply({
+        content: `Daily verse set for <#${channel.id}> at ${time} ${timezone}.`,
+        ephemeral: true,
+      });
+    } else if (sub === "status") {
+      const settings = await getOne(interaction.guildId);
+      if (settings) {
+        await interaction.reply({
+          content: `Channel: <#${settings.channel_id}>\nTime: ${settings.time} ${settings.timezone}`,
+          ephemeral: true,
+        });
+      } else {
+        await interaction.reply({
+          content: "No daily verse settings found.",
+          ephemeral: true,
+        });
+      }
+    } else if (sub === "clear") {
+      await clearOne(interaction.guildId);
+      await setupDailyVerse(interaction.client);
+      await interaction.reply({
+        content: "Daily verse settings cleared.",
+        ephemeral: true,
+      });
     }
-
-    // Reschedule tasks in case configuration has changed
-    await setupDailyVerse(interaction.client);
   },
 };
+

--- a/commands/brhelp.js
+++ b/commands/brhelp.js
@@ -12,7 +12,11 @@ module.exports = {
       .setTitle("List of Available Commands Below")
       .setDescription("Here are the commands you can use:")
       .addFields(
-        { name: "/brdaily", value: "Sends the daily verse.", inline: false },
+        {
+          name: "/brdaily",
+          value: "Manage daily verse settings (set, status, clear).",
+          inline: false,
+        },
         {
           name: "/brmypoints",
           value: "Displays your trivia points and ranking.",

--- a/src/db/guild-settings.js
+++ b/src/db/guild-settings.js
@@ -75,10 +75,25 @@ function deleteDailySettings(guildId) {
   });
 }
 
+function getOne(guildId) {
+  return getDailySettings(guildId);
+}
+
+function setOne(guildId, channelId, time, timezone) {
+  return setDailySettings(guildId, channelId, time, timezone);
+}
+
+function clearOne(guildId) {
+  return deleteDailySettings(guildId);
+}
+
 module.exports = {
   getAllDailySettings,
   getDailySettings,
   setDailySettings,
   deleteDailySettings,
+  getOne,
+  setOne,
+  clearOne,
 };
 


### PR DESCRIPTION
## Summary
- Replace `/brdaily` with `set`, `status`, and `clear` subcommands
- Validate time and timezone, persist settings, and reschedule jobs
- Update help text and README for new command

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b49bb716dc83249056312df4d5515e