### PR TITLE
Add daily reading plan commands and scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules/
+/db/

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const { Client, Collection, GatewayIntentBits } = require("discord.js");
 const { setupDailyVerse } = require("./scheduler/dailyVerseScheduler"); // Correct import
+const { setupPlanScheduler } = require("./scheduler/planScheduler");
 const { handleButtons: handleLexButtons } = require("./src/commands/brlex");
 
 const client = new Client({
@@ -67,6 +68,7 @@ if (fs.existsSync(buttonsPath)) {
 client.once("ready", async () => {
   console.log(`Logged in as ${client.user.tag}`);
   await setupDailyVerse(client); // Set up the daily verse scheduler when the client is ready
+  await setupPlanScheduler(client);
 });
 
 client.on("interactionCreate", async (interaction) => {

--- a/plan_defs.json
+++ b/plan_defs.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "genesis",
+    "name": "Genesis 1-3",
+    "description": "Three day reading plan through Genesis 1-3",
+    "days": [
+      "Genesis 1",
+      "Genesis 2",
+      "Genesis 3"
+    ]
+  }
+]

--- a/scheduler/planScheduler.js
+++ b/scheduler/planScheduler.js
@@ -1,0 +1,44 @@
+const cron = require('node-cron');
+const moment = require('moment-timezone');
+const {
+  getAllUserPlans,
+  getPlanDef,
+  advanceDay,
+  deleteUserPlan,
+} = require('../src/db/plan');
+
+let task = null;
+
+function setupPlanScheduler(client) {
+  if (task) task.stop();
+  task = cron.schedule('0 * * * *', async () => {
+    let plans;
+    try {
+      plans = await getAllUserPlans();
+    } catch (err) {
+      console.error('Failed to load user plans:', err);
+      return;
+    }
+    for (const up of plans) {
+      const today = moment().tz(up.timezone).format('YYYY-MM-DD');
+      if (up.last_dm === today) continue;
+      const def = await getPlanDef(up.plan_id);
+      if (!def) continue;
+      const dayIndex = up.current_day - 1;
+      const user = await client.users.fetch(up.user_id).catch(() => null);
+      if (!user) continue;
+      if (dayIndex >= def.days.length) {
+        await user.send(`Reading plan "${def.name}" complete!`).catch(() => {});
+        await deleteUserPlan(up.user_id);
+        continue;
+      }
+      const reading = def.days[dayIndex];
+      await user
+        .send(`Day ${up.current_day}: ${reading}`)
+        .catch(() => {});
+      await advanceDay(up.user_id, up.current_day + 1, today);
+    }
+  });
+}
+
+module.exports = { setupPlanScheduler };

--- a/src/commands/brplan.js
+++ b/src/commands/brplan.js
@@ -1,0 +1,106 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const moment = require('moment-timezone');
+const {
+  getPlanDef,
+  getUserPlan,
+  createUserPlan,
+  advanceDay,
+  updateCompletion,
+  logCompletion,
+} = require('../db/plan');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('brplan')
+    .setDescription('Manage Bible reading plans')
+    .addSubcommand((sub) =>
+      sub
+        .setName('start')
+        .setDescription('Start a reading plan')
+        .addStringOption((opt) =>
+          opt.setName('plan').setDescription('Plan ID').setRequired(true)
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName('timezone')
+            .setDescription('Your IANA timezone, e.g., America/New_York')
+            .setRequired(true)
+        )
+    )
+    .addSubcommand((sub) =>
+      sub.setName('complete').setDescription("Mark today's reading complete")
+    )
+    .addSubcommand((sub) =>
+      sub.setName('status').setDescription('Show your plan status')
+    ),
+
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    const userId = interaction.user.id;
+
+    if (sub === 'start') {
+      const planId = interaction.options.getString('plan');
+      const timezone = interaction.options.getString('timezone');
+      const def = await getPlanDef(planId);
+      if (!def) {
+        await interaction.reply({
+          content: 'Unknown plan.',
+          ephemeral: true,
+        });
+        return;
+      }
+      await createUserPlan(userId, planId, timezone);
+      const today = moment().tz(timezone).format('YYYY-MM-DD');
+      const reading = def.days[0];
+      await interaction.user
+        .send(`Day 1: ${reading}`)
+        .catch(() => {});
+      await advanceDay(userId, 2, today);
+      await interaction.reply({
+        content: `Started plan "${def.name}". Check your DMs for day 1!`,
+        ephemeral: true,
+      });
+    } else if (sub === 'complete') {
+      const plan = await getUserPlan(userId);
+      if (!plan) {
+        await interaction.reply({
+          content: 'You are not enrolled in a plan.',
+          ephemeral: true,
+        });
+        return;
+      }
+      const today = moment().tz(plan.timezone).format('YYYY-MM-DD');
+      if (plan.last_completed === today) {
+        await interaction.reply({
+          content: "You've already marked today's reading complete.",
+          ephemeral: true,
+        });
+        return;
+      }
+      const yesterday = moment(today).subtract(1, 'day').format('YYYY-MM-DD');
+      const streak = plan.last_completed === yesterday ? plan.streak + 1 : 1;
+      const dayCompleted = plan.current_day - 1;
+      await logCompletion(userId, plan.plan_id, dayCompleted);
+      await updateCompletion(userId, streak, today);
+      await interaction.reply({
+        content: `Marked day ${dayCompleted} complete. Current streak: ${streak}.`,
+        ephemeral: true,
+      });
+    } else if (sub === 'status') {
+      const plan = await getUserPlan(userId);
+      if (!plan) {
+        await interaction.reply({
+          content: 'You are not enrolled in a plan.',
+          ephemeral: true,
+        });
+        return;
+      }
+      const def = await getPlanDef(plan.plan_id);
+      const day = plan.current_day - 1;
+      await interaction.reply({
+        content: `Plan: ${def?.name || plan.plan_id}\nDay: ${day}\nStreak: ${plan.streak}`,
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/src/db/plan.js
+++ b/src/db/plan.js
@@ -1,0 +1,203 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const fs = require('fs');
+
+const dbDir = path.join(__dirname, '..', '..', 'db');
+if (!fs.existsSync(dbDir)) {
+  fs.mkdirSync(dbDir, { recursive: true });
+}
+
+const dbPath = path.join(dbDir, 'bot_settings.sqlite');
+const db = new sqlite3.Database(dbPath);
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS plan_defs (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    days TEXT NOT NULL
+  )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS user_plans (
+    user_id TEXT PRIMARY KEY,
+    plan_id TEXT NOT NULL,
+    current_day INTEGER NOT NULL,
+    timezone TEXT NOT NULL,
+    streak INTEGER DEFAULT 0,
+    last_completed TEXT,
+    last_dm TEXT,
+    FOREIGN KEY(plan_id) REFERENCES plan_defs(id)
+  )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS plan_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    plan_id TEXT NOT NULL,
+    day INTEGER NOT NULL,
+    completed_at TEXT NOT NULL
+  )`);
+});
+
+function seedPlanDefs() {
+  return new Promise((resolve, reject) => {
+    db.get('SELECT COUNT(*) as count FROM plan_defs', (err, row) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      if (row.count > 0) {
+        resolve();
+        return;
+      }
+      const file = path.join(__dirname, '..', '..', 'plan_defs.json');
+      fs.readFile(file, 'utf8', (err, data) => {
+        if (err) {
+          // No seed file; resolve without error
+          resolve();
+          return;
+        }
+        let defs;
+        try {
+          defs = JSON.parse(data);
+        } catch (e) {
+          console.error('Failed to parse plan_defs.json:', e.message);
+          resolve();
+          return;
+        }
+        const stmt = db.prepare('INSERT INTO plan_defs (id, name, description, days) VALUES (?, ?, ?, ?)');
+        db.serialize(() => {
+          defs.forEach((d) => {
+            stmt.run(d.id, d.name, d.description || '', JSON.stringify(d.days || []));
+          });
+          stmt.finalize(resolve);
+        });
+      });
+    });
+  });
+}
+
+seedPlanDefs().catch((err) => console.error('Plan defs seed failed:', err));
+
+function getPlanDef(id) {
+  return new Promise((resolve, reject) => {
+    db.get('SELECT id, name, description, days FROM plan_defs WHERE id = ?', [id], (err, row) => {
+      if (err) reject(err);
+      else if (row) {
+        try {
+          row.days = JSON.parse(row.days);
+        } catch (e) {
+          row.days = [];
+        }
+        resolve(row);
+      } else resolve(null);
+    });
+  });
+}
+
+function getAllPlanDefs() {
+  return new Promise((resolve, reject) => {
+    db.all('SELECT id, name, description, days FROM plan_defs', (err, rows) => {
+      if (err) reject(err);
+      else {
+        rows = rows || [];
+        rows.forEach((r) => {
+          try { r.days = JSON.parse(r.days); } catch (e) { r.days = []; }
+        });
+        resolve(rows);
+      }
+    });
+  });
+}
+
+function getAllUserPlans() {
+  return new Promise((resolve, reject) => {
+    db.all('SELECT * FROM user_plans', (err, rows) => {
+      if (err) reject(err);
+      else resolve(rows || []);
+    });
+  });
+}
+
+function getUserPlan(userId) {
+  return new Promise((resolve, reject) => {
+    db.get('SELECT * FROM user_plans WHERE user_id = ?', [userId], (err, row) => {
+      if (err) reject(err);
+      else resolve(row);
+    });
+  });
+}
+
+function createUserPlan(userId, planId, timezone) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      `INSERT OR REPLACE INTO user_plans (user_id, plan_id, current_day, timezone, streak, last_completed, last_dm)
+       VALUES (?, ?, 1, ?, 0, NULL, NULL)`,
+      [userId, planId, timezone],
+      function (err) {
+        if (err) reject(err);
+        else resolve();
+      }
+    );
+  });
+}
+
+function advanceDay(userId, nextDay, date) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      'UPDATE user_plans SET current_day = ?, last_dm = ? WHERE user_id = ?',
+      [nextDay, date, userId],
+      function (err) {
+        if (err) reject(err);
+        else resolve();
+      }
+    );
+  });
+}
+
+function updateCompletion(userId, streak, date) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      'UPDATE user_plans SET streak = ?, last_completed = ? WHERE user_id = ?',
+      [streak, date, userId],
+      function (err) {
+        if (err) reject(err);
+        else resolve();
+      }
+    );
+  });
+}
+
+function logCompletion(userId, planId, day) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      'INSERT INTO plan_log (user_id, plan_id, day, completed_at) VALUES (?, ?, ?, ?)',
+      [userId, planId, day, new Date().toISOString()],
+      function (err) {
+        if (err) reject(err);
+        else resolve();
+      }
+    );
+  });
+}
+
+function deleteUserPlan(userId) {
+  return new Promise((resolve, reject) => {
+    db.run('DELETE FROM user_plans WHERE user_id = ?', [userId], function (err) {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+module.exports = {
+  getPlanDef,
+  getAllPlanDefs,
+  getAllUserPlans,
+  getUserPlan,
+  createUserPlan,
+  advanceDay,
+  updateCompletion,
+  logCompletion,
+  deleteUserPlan,
+};
+


### PR DESCRIPTION
## Summary
- define plan tables and seed from JSON at startup
- add brplan command to start, complete, and view reading plan status
- schedule hourly task to DM next reading block per timezone

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b49ea9fb488324843a773a60cd8193