### PR TITLE
feat: add lexical search command

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const { Client, Collection, GatewayIntentBits } = require("discord.js");
 const { setupDailyVerse } = require("./scheduler/dailyVerseScheduler"); // Correct import
 const handleAutocomplete = require("./src/interaction/autocomplete");
 const handleContextButtons = require("./src/interaction/contextButtons");
+const { handleButtons: handleLexButtons } = require("./src/commands/brlex");
 
 const client = new Client({
   intents: [
@@ -91,6 +92,8 @@ client.on("interactionCreate", async (interaction) => {
       });
     }
   } else if (interaction.isButton()) {
+    const lexHandled = await handleLexButtons(interaction);
+    if (lexHandled) return;
     // Attempt to handle context-specific buttons before other handlers
     const contextHandled = await handleContextButtons(interaction);
     if (contextHandled) return;

--- a/src/commands/brlex.js
+++ b/src/commands/brlex.js
@@ -1,0 +1,149 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+const { createAdapter } = require('../db/translations');
+const { idToName } = require('../lib/books');
+const strongsDict = require('../../db/strongs-dictionary.json');
+
+const PAGE_SIZE = 5;
+
+function encode(data) {
+  return Buffer.from(JSON.stringify(data))
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function decode(str) {
+  try {
+    let b64 = str.replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4) b64 += '=';
+    const json = Buffer.from(b64, 'base64').toString('utf8');
+    return JSON.parse(json);
+  } catch (e) {
+    return null;
+  }
+}
+
+async function findVersesByStrong(translation, strong, page = 0, pageSize = PAGE_SIZE) {
+  const adapter = await createAdapter(translation);
+  const c = adapter._cols;
+  const offset = page * pageSize;
+  const sql = `SELECT ${c.book} AS book, ${c.chapter} AS chapter, ${c.verse} AS verse, ${c.text} AS text FROM verses WHERE ${c.text} LIKE ? ORDER BY ${c.book}, ${c.chapter}, ${c.verse} LIMIT ? OFFSET ?`;
+  const pattern = `%{${strong}}%`;
+  const rows = await new Promise((resolve, reject) => {
+    adapter._db.all(sql, [pattern, pageSize + 1, offset], (err, res) => {
+      if (err) reject(err);
+      else resolve(res);
+    });
+  });
+  adapter.close();
+  return rows;
+}
+
+function cleanText(text) {
+  return text.replace(/\{[^}]+\}/g, '').trim();
+}
+
+function lexEmbed(strong, entry, verses, page) {
+  const embed = new EmbedBuilder();
+  embed.setTitle(strong);
+  if (entry) {
+    const parts = [];
+    if (entry.lemma) parts.push(entry.lemma);
+    if (entry.translit) parts.push(entry.translit);
+    if (entry.gloss) parts.push(entry.gloss);
+    embed.setDescription(parts.join(' — '));
+  } else {
+    embed.setDescription('No dictionary entry found.');
+  }
+  verses.slice(0, PAGE_SIZE).forEach((v) => {
+    const ref = `${idToName(v.book)} ${v.chapter}:${v.verse}`;
+    embed.addFields({ name: ref, value: cleanText(v.text) });
+  });
+  embed.setFooter({ text: `Page ${page + 1}` });
+  return embed;
+}
+
+async function commandExecute(interaction) {
+  const strong = (interaction.options.getString('strong') || '').toUpperCase();
+  const translationOpt = interaction.options.getString('translation') || 'kjv';
+  const translation = translationOpt === 'asv' ? 'asvs' : 'kjv_strongs';
+
+  const entry = strongsDict[strong];
+  const rows = await findVersesByStrong(translation, strong, 0, PAGE_SIZE);
+  const embed = lexEmbed(strong, entry, rows, 0);
+  const components = [];
+  if (rows.length > PAGE_SIZE) {
+    const payload = encode({ strong, translation, page: 0 });
+    const next = new ButtonBuilder()
+      .setCustomId(`brlex:next:${payload}`)
+      .setLabel('Next')
+      .setStyle(ButtonStyle.Secondary);
+    components.push(new ActionRowBuilder().addComponents(next));
+  }
+  await interaction.reply({ embeds: [embed], components });
+}
+
+async function handleButtons(interaction) {
+  const id = interaction.customId || '';
+  if (!id.startsWith('brlex:')) return false;
+  const [, action, payload] = id.split(':');
+  const data = decode(payload);
+  if (!data) return false;
+  let { strong, translation, page } = data;
+  const entry = strongsDict[strong];
+  if (action === 'next') page += 1;
+  else if (action === 'prev') page -= 1;
+  if (page < 0) page = 0;
+  const rows = await findVersesByStrong(translation, strong, page, PAGE_SIZE);
+  const embed = lexEmbed(strong, entry, rows, page);
+  const buttons = [];
+  if (page > 0) {
+    const prevPayload = encode({ strong, translation, page: page - 1 });
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId(`brlex:prev:${prevPayload}`)
+        .setLabel('Prev')
+        .setStyle(ButtonStyle.Secondary)
+    );
+  }
+  if (rows.length > PAGE_SIZE) {
+    const nextPayload = encode({ strong, translation, page: page + 1 });
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId(`brlex:next:${nextPayload}`)
+        .setLabel('Next')
+        .setStyle(ButtonStyle.Secondary)
+    );
+  }
+  const components = buttons.length ? [new ActionRowBuilder().addComponents(buttons)] : [];
+  await interaction.update({ embeds: [embed], components });
+  return true;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('brlex')
+    .setDescription("Look up Strong's entries and related verses")
+    .addStringOption((opt) =>
+      opt
+        .setName('strong')
+        .setDescription("Strong's number, e.g., G3056")
+        .setRequired(true)
+    )
+    .addStringOption((opt) =>
+      opt
+        .setName('translation')
+        .setDescription('Bible translation')
+        .addChoices(
+          { name: 'ASV', value: 'asv' },
+          { name: 'KJV', value: 'kjv' }
+        )
+    ),
+  execute: commandExecute,
+  handleButtons,
+  findVersesByStrong,
+  lexEmbed,
+};
+

--- a/test/brlex.test.js
+++ b/test/brlex.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { findVersesByStrong } = require('../src/commands/brlex');
+
+const STRONG = 'G3056';
+
+// Use small page size to test pagination easily
+const PAGE_SIZE = 2;
+
+test('findVersesByStrong finds verses for Greek code', async () => {
+  const verses = await findVersesByStrong('kjv_strongs', STRONG, 0, PAGE_SIZE);
+  assert.ok(verses.length > 0);
+  const first = verses[0];
+  assert.equal(first.book, 40); // Matthew
+});
+
+test('findVersesByStrong paginates results', async () => {
+  const first = await findVersesByStrong('kjv_strongs', STRONG, 0, PAGE_SIZE);
+  const second = await findVersesByStrong('kjv_strongs', STRONG, 1, PAGE_SIZE);
+  assert.ok(second.length > 0);
+  // Ensure at least one verse differs between pages
+  assert.notEqual(first[0].verse, second[0].verse);
+});
+

--- a/test/brsearch.test.js
+++ b/test/brsearch.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 test('brsearch truncates long results with notice', async () => {
-  const searchModulePath = path.resolve(__dirname, '../SearchEngine.js');
+  const searchPath = path.resolve(__dirname, '../src/search/searchSmart.js');
 
   const longText = 'x'.repeat(500);
   const fakeResults = Array.from({ length: 10 }, (_, i) => ({
@@ -13,7 +13,7 @@ test('brsearch truncates long results with notice', async () => {
     text: longText,
   }));
 
-  require.cache[searchModulePath] = {
+  require.cache[searchPath] = {
     exports: async () => fakeResults,
   };
 


### PR DESCRIPTION
## Summary
- add `/brlex` for Strong's dictionary lookups with paginated verse results
- support base64url `Prev`/`Next` buttons and central button handler
- test lexicon search pagination and brsearch truncation

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b4abb3125c8324a10f8eb24b5553c5