### PR TITLE
feat: add topic search and pagination

### DIFF
--- a/commands/brsearch.js
+++ b/commands/brsearch.js
@@ -1,85 +1,231 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
+const {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} = require('discord.js');
 const { idToName } = require('../src/lib/books');
 const openReadingAdapter = require('../src/utils/openReadingAdapter');
+const { openReading } = require('../src/db/openReading');
 const searchSmart = require('../src/search/searchSmart');
-const { parseRef } = require('../src/utils/refs');
+
+const MAX_TEXT_RESULTS = 50;
+const MAX_TOPIC_RESULTS = 200;
+const MESSAGE_LIMIT = 2000;
+
+function encode(data) {
+  return Buffer.from(JSON.stringify(data))
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function decode(str) {
+  try {
+    let b64 = str.replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4) b64 += '=';
+    return JSON.parse(Buffer.from(b64, 'base64').toString('utf8'));
+  } catch (e) {
+    return null;
+  }
+}
+
+function splitPages(lines, limit = MESSAGE_LIMIT) {
+  const pages = [];
+  let buffer = [];
+  let length = 0;
+  for (const line of lines) {
+    const addition = (buffer.length ? 1 : 0) + line.length;
+    if (length + addition > limit) {
+      pages.push(buffer.join('\n'));
+      buffer = [line];
+      length = line.length;
+    } else {
+      buffer.push(line);
+      length += addition;
+    }
+  }
+  if (buffer.length) pages.push(buffer.join('\n'));
+  return pages;
+}
+
+function buildButtons(type, query, translation, page, total) {
+  const buttons = [];
+  if (page > 0) {
+    const payload = encode({ type, query, translation, page: page - 1 });
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId(`brsearch:prev:${payload}`)
+        .setLabel('Prev')
+        .setStyle(ButtonStyle.Secondary)
+    );
+  }
+  if (page < total - 1) {
+    const payload = encode({ type, query, translation, page: page + 1 });
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId(`brsearch:next:${payload}`)
+        .setLabel('Next')
+        .setStyle(ButtonStyle.Secondary)
+    );
+  }
+  return buttons.length ? [new ActionRowBuilder().addComponents(buttons)] : [];
+}
+
+async function textPage(query, translation, page = 0, adapter) {
+  let own = false;
+  if (!adapter) {
+    adapter = await openReading(translation);
+    own = true;
+  }
+  try {
+    const results = await searchSmart(adapter, query, MAX_TEXT_RESULTS);
+    if (!results.length) return { content: 'No results found.', components: [] };
+    const lines = results.map(
+      (r) => `${idToName(r.book)} ${r.chapter}:${r.verse} - ${r.snippet || r.text}`
+    );
+    const pages = splitPages(lines);
+    if (!pages.length) return { content: 'No results found.', components: [] };
+    if (page >= pages.length) page = pages.length - 1;
+    let content = pages[page];
+    const pageInfo = pages.length > 1 ? `\n\nPage ${page + 1}/${pages.length}` : '';
+    if (content.length + pageInfo.length <= MESSAGE_LIMIT) content += pageInfo;
+    const components = buildButtons('text', query, translation, page, pages.length);
+    return { content, components };
+  } finally {
+    if (own && adapter && adapter.close) adapter.close();
+  }
+}
+
+function summarizeTopic(results) {
+  const groups = new Map();
+  results.forEach((r) => {
+    if (!groups.has(r.book)) groups.set(r.book, []);
+    groups.get(r.book).push(r);
+  });
+  const clusters = Array.from(groups.entries()).map(([book, rows]) => {
+    rows.sort((a, b) =>
+      a.chapter - b.chapter || a.verse - b.verse
+    );
+    const samples = rows
+      .slice(0, 3)
+      .map((r) => `${r.chapter}:${r.verse}`)
+      .join(', ');
+    const sampleText = rows.length > 3 ? `${samples}…` : samples;
+    return {
+      book,
+      count: rows.length,
+      line: `${idToName(book)}: ${rows.length} hits (${sampleText})`,
+    };
+  });
+  clusters.sort((a, b) => b.count - a.count);
+  return clusters.map((c) => c.line);
+}
+
+async function topicPage(query, translation, page = 0, adapter) {
+  let own = false;
+  if (!adapter) {
+    adapter = await openReading(translation);
+    own = true;
+  }
+  try {
+    const results = await searchSmart(adapter, query, MAX_TOPIC_RESULTS);
+    if (!results.length) return { content: 'No results found.', components: [] };
+    const lines = summarizeTopic(results);
+    const pages = splitPages(lines);
+    if (!pages.length) return { content: 'No results found.', components: [] };
+    if (page >= pages.length) page = pages.length - 1;
+    let content = pages[page];
+    const pageInfo = pages.length > 1 ? `\n\nPage ${page + 1}/${pages.length}` : '';
+    if (content.length + pageInfo.length <= MESSAGE_LIMIT) content += pageInfo;
+    const components = buildButtons('topic', query, translation, page, pages.length);
+    return { content, components };
+  } finally {
+    if (own && adapter && adapter.close) adapter.close();
+  }
+}
+
+async function execute(interaction) {
+  const sub = interaction.options.getSubcommand();
+  const query = interaction.options.getString('query');
+  await interaction.deferReply();
+  let adapter;
+  let translation;
+  try {
+    ({ adapter, translation } = await openReadingAdapter(interaction));
+    const pageFn = sub === 'topic' ? topicPage : textPage;
+    const res = await pageFn(query, translation, 0, adapter);
+    await interaction.editReply(res);
+  } catch (err) {
+    console.error('Error performing search:', err);
+    await interaction.editReply('There was an error executing this command.');
+  } finally {
+    if (adapter && adapter.close) adapter.close();
+  }
+}
+
+async function handleButtons(interaction) {
+  const id = interaction.customId || '';
+  if (!id.startsWith('brsearch:')) return false;
+  const [, action, payload] = id.split(':');
+  const data = decode(payload);
+  if (!data) return false;
+  let { type, query, translation, page } = data;
+  if (action === 'next') page += 1;
+  else if (action === 'prev') page -= 1;
+  if (page < 0) page = 0;
+  const pageFn = type === 'topic' ? topicPage : textPage;
+  const res = await pageFn(query, translation, page);
+  await interaction.update(res);
+  return true;
+}
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('brsearch')
     .setDescription('Search Bible verses')
-    .addStringOption(option =>
-      option
-        .setName('query')
-        .setDescription('Search query')
-        .setRequired(true)
+    .addSubcommand((sub) =>
+      sub
+        .setName('text')
+        .setDescription('Search verses by text or reference')
+        .addStringOption((opt) =>
+          opt
+            .setName('query')
+            .setDescription('Search query')
+            .setRequired(true)
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName('translation')
+            .setDescription('Bible translation')
+            .addChoices(
+              { name: 'ASV', value: 'asv' },
+              { name: 'KJV', value: 'kjv' }
+            )
+        )
     )
-    .addStringOption(option =>
-      option
-        .setName('translation')
-        .setDescription('Bible translation')
-        .addChoices(
-          { name: 'ASV', value: 'asv' },
-          { name: 'KJV', value: 'kjv' }
+    .addSubcommand((sub) =>
+      sub
+        .setName('topic')
+        .setDescription('Summarize results by book')
+        .addStringOption((opt) =>
+          opt
+            .setName('query')
+            .setDescription('Search query')
+            .setRequired(true)
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName('translation')
+            .setDescription('Bible translation')
+            .addChoices(
+              { name: 'ASV', value: 'asv' },
+              { name: 'KJV', value: 'kjv' }
+            )
         )
     ),
-
-  async execute(interaction) {
-    const query = interaction.options.getString('query');
-    const ref = parseRef(query);
-    const isRange =
-      ref && Array.isArray(ref.verses) && ref.verses.length > 1 && query.includes('-');
-
-    await interaction.deferReply();
-    let adapter;
-    try {
-      ({ adapter } = await openReadingAdapter(interaction));
-      const results = await searchSmart(adapter, query, 10);
-      if (!results.length) {
-        if (isRange) {
-          await interaction.editReply("That verse range doesn’t exist in this chapter.");
-        } else {
-          await interaction.editReply('No results found.');
-        }
-        return;
-      }
-
-      const lines = results.map(
-        (r) => `${idToName(r.book)} ${r.chapter}:${r.verse} - ${r.snippet || r.text}`
-      );
-
-      const limit = 2000;
-      const marker = '[results truncated]';
-      const buffer = [];
-      let currentLength = 0;
-      let truncated = false;
-      for (const line of lines) {
-        const addition = (buffer.length ? 1 : 0) + line.length;
-        if (currentLength + addition > limit) {
-          truncated = true;
-          break;
-        }
-        buffer.push(line);
-        currentLength += addition;
-      }
-
-      let output = buffer.join('\n');
-      if (truncated) {
-        const markerAddition = (output.length ? 1 : 0) + marker.length;
-        while (output.length + markerAddition > limit && buffer.length) {
-          buffer.pop();
-          output = buffer.join('\n');
-        }
-        if (output.length) output += '\n';
-        output += marker;
-      }
-
-      await interaction.editReply(output);
-    } catch (err) {
-      console.error('Error performing search:', err);
-      await interaction.editReply('There was an error executing this command.');
-    } finally {
-      if (adapter && adapter.close) adapter.close();
-    }
-  },
+  execute,
+  handleButtons,
 };
+

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const { setupPlanScheduler } = require("./scheduler/planScheduler");
 const handleAutocomplete = require("./src/interaction/autocomplete");
 const handleContextButtons = require("./src/interaction/contextButtons");
 const { handleButtons: handleLexButtons } = require("./src/commands/brlex");
+const { handleButtons: handleSearchButtons } = require("./commands/brsearch");
 
 const client = new Client({
   intents: [
@@ -96,6 +97,8 @@ client.on("interactionCreate", async (interaction) => {
   } else if (interaction.isButton()) {
     const lexHandled = await handleLexButtons(interaction);
     if (lexHandled) return;
+    const searchHandled = await handleSearchButtons(interaction);
+    if (searchHandled) return;
     // Attempt to handle context-specific buttons before other handlers
     const contextHandled = await handleContextButtons(interaction);
     if (contextHandled) return;

--- a/test/brsearch.test.js
+++ b/test/brsearch.test.js
@@ -2,8 +2,9 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
 
-test('brsearch truncates long results with notice', async () => {
+test('brsearch text paginates long results', async () => {
   const searchPath = path.resolve(__dirname, '../src/search/searchSmart.js');
+  const openPath = path.resolve(__dirname, '../src/utils/openReadingAdapter.js');
 
   const longText = 'x'.repeat(500);
   const fakeResults = Array.from({ length: 10 }, (_, i) => ({
@@ -13,16 +14,20 @@ test('brsearch truncates long results with notice', async () => {
     text: longText,
   }));
 
-  require.cache[searchPath] = {
-    exports: async () => fakeResults,
+  require.cache[searchPath] = { exports: async () => fakeResults };
+  require.cache[openPath] = {
+    exports: async () => ({ adapter: { close() {} }, translation: 'asv' }),
   };
 
+  delete require.cache[require.resolve('../commands/brsearch.js')];
   const brsearch = require('../commands/brsearch.js');
 
-  let reply = '';
+  let reply = {};
   const interaction = {
     options: {
-      getString: (name) => (name === 'query' ? 'dummy' : name === 'translation' ? 'asv' : null),
+      getSubcommand: () => 'text',
+      getString: (name) =>
+        name === 'query' ? 'dummy' : name === 'translation' ? 'asv' : null,
     },
     user: { id: 'user' },
     deferReply: () => Promise.resolve(),
@@ -34,7 +39,46 @@ test('brsearch truncates long results with notice', async () => {
 
   await brsearch.execute(interaction);
 
-  assert.ok(reply.endsWith('[results truncated]'));
-  assert.ok(reply.length <= 2000);
+  assert.ok(reply.content.length <= 2000);
+  assert.ok(reply.components.length > 0);
+});
+
+test('brsearch topic groups results by book', async () => {
+  const searchPath = path.resolve(__dirname, '../src/search/searchSmart.js');
+  const openPath = path.resolve(__dirname, '../src/utils/openReadingAdapter.js');
+
+  const fakeResults = [
+    { book: 1, chapter: 1, verse: 1, text: 'a' },
+    { book: 1, chapter: 1, verse: 2, text: 'b' },
+    { book: 2, chapter: 1, verse: 1, text: 'c' },
+  ];
+
+  require.cache[searchPath] = { exports: async () => fakeResults };
+  require.cache[openPath] = {
+    exports: async () => ({ adapter: { close() {} }, translation: 'asv' }),
+  };
+
+  delete require.cache[require.resolve('../commands/brsearch.js')];
+  const brsearch = require('../commands/brsearch.js');
+
+  let reply = {};
+  const interaction = {
+    options: {
+      getSubcommand: () => 'topic',
+      getString: (name) =>
+        name === 'query' ? 'dummy' : name === 'translation' ? 'asv' : null,
+    },
+    user: { id: 'user' },
+    deferReply: () => Promise.resolve(),
+    editReply: (msg) => {
+      reply = msg;
+      return Promise.resolve();
+    },
+  };
+
+  await brsearch.execute(interaction);
+
+  assert.ok(/Genesis/.test(reply.content));
+  assert.ok(/Exodus/.test(reply.content));
 });
 


### PR DESCRIPTION
## Summary
- add button-driven pagination for search results
- support `/brsearch topic` for book-level clustering of up to 200 hits
- wire button handler for search navigation

## Testing
- `npm test` *(fails: Missing script)*
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d7ee552483249ceac6267adf562c