### PR TITLE
Expand help command coverage

### DIFF
--- a/commands/brhelp.js
+++ b/commands/brhelp.js
@@ -35,9 +35,29 @@ module.exports = {
             inline: false,
           },
           {
-            name: "/verse",
+            name: "/brverse",
             value: "Fetch a verse from the Bible.",
             inline: false,
+          },
+          {
+            name: "/brtranslation",
+            value: "Set your preferred Bible translation.",
+            inline: false,
+          },
+          {
+            name: "/brplan",
+            value: "Manage reading plans.",
+            inline: false,
+          },
+          {
+            name: "/brcardverse",
+            value: "Render a verse on a shareable card.",
+            inline: false,
+          },
+          {
+            name: "/brlex",
+            value: "Look up Strong's entries and verses.",
+            inline: false
           }
         )
       .setTimestamp();


### PR DESCRIPTION
## Summary
- replace `/verse` with `/brverse`
- document `/brtranslation`, `/brplan`, `/brcardverse`, and `/brlex`
- ensure all listed commands use the `br` prefix

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4dc961d308324b0b3a8ec19d25dc5