### PR TITLE
chore: remove unused scheduler config files

### DIFF
--- a/scheduler/dailyVerse.json
+++ b/scheduler/dailyVerse.json
@@ -1,1 +1,0 @@
-{"verse":"Judges 17:9: And Micah said unto him, Whence comest thou? And he said unto him, I am a Levite of Beth-lehem-judah, and I go to sojourn where I may find a place."}

--- a/scheduler/dailybread.json
+++ b/scheduler/dailybread.json
@@ -1,5 +1,0 @@
-{
-  "time": "07:00",
-  "timezone": "America/New_York",
-  "channelId": "1251338363642974268"
-}


### PR DESCRIPTION
## Summary
- remove obsolete scheduler config JSON files

## Testing
- `node - <<'NODE'...` (setSettings/setupDailyVerse)
- `node - <<'NODE'...` (startPlan/setupPlanScheduler)


------
https://chatgpt.com/codex/tasks/task_e_68b4df9c114c8324b725bb81d54817a0