### PR TITLE
refactor: update brtranslation command

### DIFF
--- a/src/commands/brtranslation.js
+++ b/src/commands/brtranslation.js
@@ -1,5 +1,5 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
-const { setUserTranslation } = require('../db/users');
+const { SlashCommandBuilder } = require('discord.js');
+const { setUserTranslation } = require('../db/user-prefs');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -11,17 +11,16 @@ module.exports = {
         .setDescription('Translation to use')
         .setRequired(true)
         .addChoices(
-          { name: 'ASV', value: 'asv' },
-          { name: 'KJV', value: 'kjv' }
+          { name: 'ASV (reading)', value: 'asv' },
+          { name: 'KJV (reading)', value: 'kjv' }
         )
     ),
   async execute(interaction) {
-    const translation = interaction.options.getString('set');
+    const t = interaction.options.getString('set');
     try {
-      await setUserTranslation(interaction.user.id, translation);
-      const pretty = translation === 'asv' ? 'ASV' : 'KJV';
+      await setUserTranslation(interaction.user.id, t);
       await interaction.reply({
-        content: `Translation set to ${pretty}.`,
+        content: `Saved. Your default reading translation is **${t.toUpperCase()}**.`,
         ephemeral: true,
       });
     } catch (err) {


### PR DESCRIPTION
## Summary
- update brtranslation to use SlashCommandBuilder from discord.js
- pull setUserTranslation from user-prefs and add ASV/KJV reading choices
- clarify user feedback when setting default translation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4ebc0f834832488eb8b8f207a8139