### PR TITLE
feat: enhance plan command

### DIFF
--- a/src/commands/brplan.js
+++ b/src/commands/brplan.js
@@ -1,10 +1,13 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
-const { startPlan, completeDay, getPlanDef, updateLastNotified } = require('../db/plans');
-const planDefs = require('../../plan_defs.json');
 
-function today() {
-  return new Date().toISOString().slice(0, 10);
-}
+const { SlashCommandBuilder } = require('discord.js');
+const {
+  getPlan,
+  setUserPlan,
+  getUserPlan,
+  advanceDay,
+  logComplete,
+} = require('../db/plans');
+const planDefs = require('../../plan_defs.json');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -21,6 +24,12 @@ module.exports = {
         })
     )
     .addSubcommand((sub) =>
+      sub.setName('status').setDescription('Show your reading plan status')
+    )
+    .addSubcommand((sub) =>
+      sub.setName('stop').setDescription('Stop the active reading plan')
+    )
+    .addSubcommand((sub) =>
       sub.setName('complete').setDescription("Mark today's reading as complete")
     ),
   async execute(interaction) {
@@ -29,12 +38,15 @@ module.exports = {
     if (sub === 'start') {
       const planId = interaction.options.getString('plan');
       try {
-        await startPlan(userId, planId);
-        const plan = await getPlanDef(planId);
+        const plan = await getPlan(planId);
+        if (!plan) {
+          await interaction.reply({ content: 'Plan not found.', ephemeral: true });
+          return;
+        }
+        await setUserPlan(userId, planId);
         const reading = plan.days[0];
         try {
           await interaction.user.send(`Day 1: ${reading}`);
-          await updateLastNotified(userId, today());
         } catch (err) {
           console.error('Failed to send DM:', err);
         }
@@ -45,30 +57,64 @@ module.exports = {
       } catch (err) {
         await interaction.reply({ content: 'Failed to start plan.', ephemeral: true });
       }
+    } else if (sub === 'status') {
+      try {
+        const userPlan = await getUserPlan(userId);
+        if (!userPlan) {
+          await interaction.reply({ content: 'No active plan.', ephemeral: true });
+          return;
+        }
+        const plan = await getPlan(userPlan.plan_id || userPlan.planId);
+        const day = userPlan.day || 0;
+        await interaction.reply({
+          content: `Reading plan: **${plan.name}**. Day ${day + 1} of ${plan.days.length}. Current streak: ${userPlan.streak || 0}.`,
+          ephemeral: true,
+        });
+      } catch (err) {
+        await interaction.reply({ content: 'Failed to get status.', ephemeral: true });
+      }
+    } else if (sub === 'stop') {
+      try {
+        const userPlan = await getUserPlan(userId);
+        if (!userPlan) {
+          await interaction.reply({ content: 'No active plan to stop.', ephemeral: true });
+          return;
+        }
+        await setUserPlan(userId, null);
+        await interaction.reply({ content: 'Stopped the current reading plan.', ephemeral: true });
+      } catch (err) {
+        await interaction.reply({ content: 'Failed to stop plan.', ephemeral: true });
+      }
     } else if (sub === 'complete') {
       try {
-        const res = await completeDay(userId);
-        if (res.nextReading) {
+        const userPlan = await getUserPlan(userId);
+        if (!userPlan) {
+          await interaction.reply({ content: 'No active plan.', ephemeral: true });
+          return;
+        }
+        const plan = await getPlan(userPlan.plan_id || userPlan.planId);
+        await logComplete(userId, plan.id, userPlan.day);
+        const { day: nextDay, streak } = await advanceDay(userId);
+        const nextReading = plan.days[nextDay];
+        if (nextReading) {
           try {
-            await interaction.user.send(`Day ${res.nextDay}: ${res.nextReading}`);
-            await updateLastNotified(userId, today());
+            await interaction.user.send(`Day ${nextDay + 1}: ${nextReading}`);
           } catch (err) {
             console.error('Failed to send DM:', err);
           }
         } else {
           try {
             await interaction.user.send('Plan completed!');
-            await updateLastNotified(userId, today());
           } catch (err) {
             console.error('Failed to send DM:', err);
           }
         }
         await interaction.reply({
-          content: `Day ${res.nextDay - 1} completed. Current streak: ${res.streak}`,
+          content: `Day ${nextDay} completed. Current streak: ${streak}`,
           ephemeral: true,
         });
       } catch (err) {
-        await interaction.reply({ content: err.message, ephemeral: true });
+        await interaction.reply({ content: err.message || 'Failed to complete day.', ephemeral: true });
       }
     }
   },


### PR DESCRIPTION
## Summary
- import SlashCommandBuilder from discord.js
- support reading plan status and stop subcommands
- update command to use new plan DB helpers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4edfe63d88324914a84583b37bbe9