### PR TITLE
feat: add translation fallback for reading

### DIFF
--- a/src/db/openReading.js
+++ b/src/db/openReading.js
@@ -45,4 +45,13 @@ async function openReading(translation = 'asv', options = {}) {
   }
 }
 
-module.exports = { openReading, openReadingAdapter: openReading };
+async function openReadingAdapter(preferred = 'asv', options = {}) {
+  try {
+    return await openReading(preferred, options);
+  } catch (err) {
+    const fallback = preferred === 'kjv' ? 'asv' : 'kjv';
+    return openReading(fallback, options);
+  }
+}
+
+module.exports = { openReading, openReadingAdapter };


### PR DESCRIPTION
## Summary
- add `openReadingAdapter` with fallback to alternate translation

## Testing
- `node --test` *(fails: translation.toLowerCase is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f3b54534832489e549fe677b6459