### PR TITLE
Refactor user prefs DB access

### DIFF
--- a/src/db/user-prefs.js
+++ b/src/db/user-prefs.js
@@ -2,20 +2,42 @@ const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
 
 const dbPath = path.join(__dirname, '..', '..', 'db', 'bot_settings.sqlite');
-const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE);
 
-db.serialize(() => {
-  db.run(`CREATE TABLE IF NOT EXISTS user_prefs (
-    user_id TEXT PRIMARY KEY,
-    translation TEXT CHECK(translation IN ('asv','kjv')),
-    updated_at INTEGER
-  )`);
-
-  // One-time migration to normalize legacy translation values
-  db.run(
-    "UPDATE user_prefs SET translation = CASE translation WHEN 'asvs' THEN 'asv' WHEN 'kjv_strongs' THEN 'kjv' ELSE translation END WHERE translation IN ('asvs','kjv_strongs')"
-  );
-});
+function withDb(fn) {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(
+      dbPath,
+      sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE,
+      (err) => {
+        if (err) return reject(err);
+        db.serialize(() => {
+          db.run(
+            `CREATE TABLE IF NOT EXISTS user_prefs (
+              user_id TEXT PRIMARY KEY,
+              translation TEXT NOT NULL CHECK(translation IN ('asv','kjv')),
+              updated_at INTEGER
+            )`
+          );
+          db.run(
+            "UPDATE user_prefs SET translation = CASE translation WHEN 'asvs' THEN 'asv' WHEN 'kjv_strongs' THEN 'kjv' ELSE translation END WHERE translation IN ('asvs','kjv_strongs')",
+            (migrationErr) => {
+              if (migrationErr) {
+                db.close(() => reject(migrationErr));
+                return;
+              }
+              fn(db, (fnErr, result) => {
+                db.close((closeErr) => {
+                  if (fnErr || closeErr) reject(fnErr || closeErr);
+                  else resolve(result);
+                });
+              });
+            }
+          );
+        });
+      }
+    );
+  });
+}
 
 function normalizeTranslation(t) {
   if (!t) return t;
@@ -25,10 +47,10 @@ function normalizeTranslation(t) {
 }
 
 function getUserTranslation(userId) {
-  return new Promise((resolve, reject) => {
+  return withDb((db, done) => {
     db.get('SELECT translation FROM user_prefs WHERE user_id = ?', [userId], (err, row) => {
-      if (err) reject(err);
-      else resolve(row ? normalizeTranslation(row.translation) : null);
+      if (err) return done(err);
+      done(null, row ? normalizeTranslation(row.translation) : null);
     });
   });
 }
@@ -36,14 +58,11 @@ function getUserTranslation(userId) {
 function setUserTranslation(userId, translation) {
   const now = Date.now();
   const normalized = normalizeTranslation(translation);
-  return new Promise((resolve, reject) => {
+  return withDb((db, done) => {
     const sql = `INSERT INTO user_prefs (user_id, translation, updated_at)
                  VALUES (?, ?, ?)
                  ON CONFLICT(user_id) DO UPDATE SET translation=excluded.translation, updated_at=excluded.updated_at`;
-    db.run(sql, [userId, normalized, now], (err) => {
-      if (err) reject(err);
-      else resolve();
-    });
+    db.run(sql, [userId, normalized, now], done);
   });
 }
 


### PR DESCRIPTION
## Summary
- add withDb helper to open and close bot_settings DB per operation
- enforce non-null translation limited to asv or kjv and normalize legacy values
- provide getUserTranslation and setUserTranslation using the helper

## Testing
- `node --test` *(fails: TypeError in brlex tests - translation.toLowerCase is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f50baa80832483c33d01b7b97d16