### PR TITLE
Seed plans during client ready event

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ if (fs.existsSync(buttonsPath)) {
 
 client.once("ready", () => {
   console.log(`Logged in as ${client.user.tag}`);
+  require("./src/boot/seedPlans")();
   setupDailyVerse(client); // Set up the daily verse scheduler when the client is ready
   setupPlanScheduler(client);
 });


### PR DESCRIPTION
## Summary
- Seed initial plans when the bot becomes ready
- Ensure daily verse and plan schedulers run after plan seeding

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4f7935c908324b4520ae59d534319