### PR TITLE
Add shared Strong's stripping helper and optional translation cleanup

### DIFF
--- a/src/db/openReading.js
+++ b/src/db/openReading.js
@@ -1,13 +1,10 @@
 const { createAdapter } = require('./translations');
+const { stripStrongs } = require('./stripStrongs');
 
 const STRONGS_FALLBACK = {
   kjv: 'kjv_strongs',
   asv: 'asvs',
 };
-
-function stripStrongs(text) {
-  return text ? text.replace(/<[GH]\d+>/gi, '') : text;
-}
 
 async function openReading(translation = 'asv', options = {}) {
   try {

--- a/src/db/stripStrongs.js
+++ b/src/db/stripStrongs.js
@@ -1,0 +1,8 @@
+const STRONGS_REGEX = /\{[GH]\s*\d{1,5}\}|\[[GH]\s*\d{1,5}\]|<\s*[GH]\s*\d{1,5}\s*>/g;
+
+function stripStrongs(text = '') {
+  if (!text) return text;
+  return text.replace(STRONGS_REGEX, '').replace(/\s+/g, ' ').trim();
+}
+
+module.exports = { STRONGS_REGEX, stripStrongs };


### PR DESCRIPTION
## Summary
- add shared STRONGS_REGEX and stripStrongs helper to remove Strong's tags and collapse whitespace
- use the new helper in openReading's fallback logic
- allow translations adapter to strip Strong's numbers when `options.stripStrongs` is set

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4fc5f8f048324b81798440f418e79