### PR TITLE
Seed plans before scheduling on Discord client ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const path = require("path");
 const { Client, Collection, GatewayIntentBits } = require("discord.js");
 const { setupDailyVerse } = require("./scheduler/dailyVerseScheduler"); // Correct import
 const { setupPlanScheduler } = require("./scheduler/planScheduler");
+const { seed } = require("./src/boot/seedPlans");
 const handleAutocomplete = require("./src/interaction/autocomplete");
 const handleContextButtons = require("./src/interaction/contextButtons");
 const { handleButtons: handleLexButtons } = require("./src/commands/brlex");
@@ -61,9 +62,9 @@ if (fs.existsSync(buttonsPath)) {
   });
 }
 
-client.once("ready", () => {
+client.once("ready", async () => {
   console.log(`Logged in as ${client.user.tag}`);
-  require("./src/boot/seedPlans")();
+  await seed();
   setupDailyVerse(client); // Set up the daily verse scheduler when the client is ready
   setupPlanScheduler(client);
 });


### PR DESCRIPTION
## Summary
- Import plan seeding utility
- Await `seed` during client readiness before starting schedulers

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4ffe8e59483248477a6d2f313520c