### PR TITLE
feat: add strongs stripping helper

### DIFF
--- a/src/db/openReading.js
+++ b/src/db/openReading.js
@@ -1,13 +1,10 @@
 const { createAdapter } = require('./translations');
+const { STRONGS_REGEX, stripStrongs } = require('./strongs');
 
 const STRONGS_FALLBACK = {
   kjv: 'kjv_strongs',
   asv: 'asvs',
 };
-
-function stripStrongs(text) {
-  return text ? text.replace(/<[GH]\d+>/gi, '') : text;
-}
 
 async function openReading(translation = 'asv', options = {}) {
   try {

--- a/src/db/strongs.js
+++ b/src/db/strongs.js
@@ -1,0 +1,7 @@
+const STRONGS_REGEX = /\{[GH]\s*\d{1,5}\}|\[[GH]\s*\d{1,5}\]|<\s*[GH]\s*\d{1,5}\s*>/g;
+
+function stripStrongs(s) {
+  return s ? s.replace(STRONGS_REGEX, '').replace(/\s{2,}/g, ' ').trim() : s;
+}
+
+module.exports = { STRONGS_REGEX, stripStrongs };

--- a/src/db/translations.js
+++ b/src/db/translations.js
@@ -1,11 +1,6 @@
 const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
-
-const STRONGS_REGEX = /(?:\{GH\d+\}|\[GH\d+\]|<GH\d+>)/gi;
-
-function stripStrongs(text) {
-  return text ? text.replace(STRONGS_REGEX, '') : text;
-}
+const { STRONGS_REGEX, stripStrongs } = require('./strongs');
 
 const FILES = {
   kjv_strongs: 'kjv_strongs.sqlite',


### PR DESCRIPTION
## Summary
- add shared `STRONGS_REGEX` and `stripStrongs` helper
- sanitize fallback verses in `openReading`
- strip Strong's numbers in `translations` when requested

## Testing
- `node --test` *(fails: translation.toLowerCase is not a function in brlex tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b502bacb088324b8f8e66ff37a383d