### PR TITLE
refactor: use discord.js SlashCommandBuilder

### DIFF
--- a/commands/brhelp.js
+++ b/commands/brhelp.js
@@ -1,5 +1,5 @@
 // commands/brhelp.js
-const { SlashCommandBuilder } = require("@discordjs/builders");
+const { SlashCommandBuilder } = require("discord.js");
 const { EmbedBuilder } = require("discord.js");
 
 module.exports = {

--- a/commands/brmypoints.js
+++ b/commands/brmypoints.js
@@ -1,5 +1,5 @@
 // commands/brmypoints.js
-const { SlashCommandBuilder } = require('@discordjs/builders');
+const { SlashCommandBuilder } = require('discord.js');
 const { getScore } = require('../src/db/trivia');
 
 function getOrdinal(n) {

--- a/commands/brpoints.js
+++ b/commands/brpoints.js
@@ -1,5 +1,5 @@
 // commands/brpoints.js
-const { SlashCommandBuilder } = require('@discordjs/builders');
+const { SlashCommandBuilder } = require('discord.js');
 const { EmbedBuilder } = require('discord.js');
 const { top } = require('../src/db/trivia');
 

--- a/commands/brsearch.js
+++ b/commands/brsearch.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
+const { SlashCommandBuilder } = require('discord.js');
 const {
   ActionRowBuilder,
   ButtonBuilder,

--- a/commands/brtrivia.js
+++ b/commands/brtrivia.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
+const { SlashCommandBuilder } = require('discord.js');
 const {
   EmbedBuilder,
   ActionRowBuilder,

--- a/src/commands/brverse.js
+++ b/src/commands/brverse.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
+const { SlashCommandBuilder } = require('discord.js');
 const { nameToId, idToName } = require('../lib/books');
 const openReadingAdapter = require('../utils/openReadingAdapter');
 const contextRow = require('../ui/contextRow');


### PR DESCRIPTION
## Summary
- use `SlashCommandBuilder` from `discord.js` across commands
- remove any leftover `@discordjs/builders` imports

## Testing
- `npm test` (fails: Missing script "test")
- `node deploy-commands.js` (fails: fetch failed due to ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_68b5041eb48c8324b616540d0a712148