### PR TITLE
feat: handle missing command modules

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -15,8 +15,12 @@ for (const dir of commandDirs) {
     .readdirSync(dir)
     .filter((file) => file.endsWith(".js"));
   for (const file of commandFiles) {
-    const command = require(`${dir}/${file}`);
-    commands.push(command.data.toJSON());
+    try {
+      const command = require(`${dir}/${file}`);
+      commands.push(command.data.toJSON());
+    } catch (err) {
+      console.error(`Failed to load command ${dir}/${file}:`, err);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- continue registering commands even if a module fails to load

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b508f0d0ec8324ad0d2cb740d974ce