### PR TITLE
Use openReadingAdapter in brcardverse

### DIFF
--- a/src/commands/brcardverse.js
+++ b/src/commands/brcardverse.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder, AttachmentBuilder } = require('discord.js');
 const { createCanvas, GlobalFonts } = require('@napi-rs/canvas');
 const path = require('path');
 const { nameToId, idToName } = require('../lib/books');
-const { openReadingAdapter } = require('../db/openReading');
+const openReadingAdapter = require('../utils/openReadingAdapter');
 
 // Register font
 const fontPath = path.join(__dirname, '..', '..', 'assets', 'Inter-Regular.ttf');
@@ -75,9 +75,9 @@ module.exports = {
     await interaction.deferReply();
 
     let adapter;
-    const translation = 'asv';
+    let translation;
     try {
-      adapter = await openReadingAdapter(translation);
+      ({ adapter, translation } = await openReadingAdapter(interaction));
       const result = await adapter.getVerse(bookId, chapter, verseNum);
       if (!result) {
         await interaction.editReply('Verse not found.');


### PR DESCRIPTION
## Summary
- Use openReadingAdapter to fetch user-preferred translation in brcardverse
- Access translation dynamically when rendering card reference

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b509aa61448324abc0c90209325607