### PR TITLE
Add role-based access control for brdaily command

### DIFF
--- a/env.example
+++ b/env.example
@@ -3,4 +3,6 @@ TOKEN=YOUR_TOKEN
 CLIENT_ID=YOUR_CLIENTID
 # On Discord right click your server icon and copy Server ID
 GUILD_ID=YOUR_SERVERID
+# Comma-separated role IDs permitted to manage daily verse scheduling
+BRDAILY_ALLOWED_ROLES=
 # Rename this file to .env

--- a/src/commands/brdaily.js
+++ b/src/commands/brdaily.js
@@ -41,6 +41,23 @@ module.exports = {
       sub.setName('clear').setDescription('Clear daily verse configuration')
     ),
   async execute(interaction) {
+    const allowed = process.env.BRDAILY_ALLOWED_ROLES;
+    const allowedRoles = allowed
+      ? allowed.split(',').map((id) => id.trim()).filter(Boolean)
+      : [];
+    if (
+      allowedRoles.length &&
+      !interaction.member.roles.cache.some((role) =>
+        allowedRoles.includes(role.id)
+      )
+    ) {
+      await interaction.reply({
+        content: 'You do not have permission to use this command.',
+        ephemeral: true,
+      });
+      return;
+    }
+
     const sub = interaction.options.getSubcommand();
     if (sub === 'set') {
       const time = interaction.options.getString('time');


### PR DESCRIPTION
## Summary
- restrict `/brdaily` command to roles listed in `BRDAILY_ALLOWED_ROLES`
- document `BRDAILY_ALLOWED_ROLES` in `env.example`

## Testing
- `node --check src/commands/brdaily.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b512904ccc83249e715f068ef1b566