### PR TITLE
Refactor brsearch button sessions

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,12 +100,12 @@ client.on("interactionCreate", async (interaction) => {
       );
     }
   } else if (interaction.isButton()) {
+    const searchHandled = await handleSearchButtons(interaction);
+    if (searchHandled) return;
     const triviaHandled = await handleTriviaButtons(interaction);
     if (triviaHandled) return;
     const lexHandled = await handleLexButtons(interaction);
     if (lexHandled) return;
-    const searchHandled = await handleSearchButtons(interaction);
-    if (searchHandled) return;
     // Attempt to handle context-specific buttons before other handlers
     const contextHandled = await handleContextButtons(interaction);
     if (contextHandled) return;


### PR DESCRIPTION
## Summary
- replace long encoded button custom IDs with short `bs:n` and `bs:p`
- maintain per-message search state in memory and export handler for buttons
- handle search buttons before other handlers in interaction router

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b51fdc66588324a23193f0377dd04c