### PR TITLE
Use LRU cache for session management and handle message deletions

### DIFF
--- a/commands/brsearch.js
+++ b/commands/brsearch.js
@@ -8,12 +8,12 @@ const {
 const { idToName } = require('../src/lib/books');
 const { openReading } = require('../src/db/openReading');
 const searchSmart = require('../src/search/searchSmart');
+const { searchSessions } = require('../src/state/sessions');
 
 const MAX_TEXT_RESULTS = 50;
 const MAX_TOPIC_RESULTS = 200;
 
 // msgId -> { type, query, translation, page, pageSize }
-const searchSessions = new Map();
 
 function buildButtons(sess, hasPrev, hasNext) {
   const buttons = [];

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const { handleButtons: handleTriviaButtons } = require("./src/commands/brtrivia"
 const { handleButtons: handleLexButtons } = require("./src/commands/brlex");
 const { handleButtons: handleSearchButtons } = require("./commands/brsearch");
 const { ephemeral } = require("./src/utils/ephemeral");
+const { activeTrivia, searchSessions } = require('./src/state/sessions');
 
 const client = new Client({
   intents: [
@@ -132,6 +133,11 @@ client.on("interactionCreate", async (interaction) => {
       }
     }
   }
+});
+
+client.on('messageDelete', (msg) => {
+  activeTrivia.delete(msg.id);
+  searchSessions.delete(msg.id);
 });
 
 client.login(process.env.TOKEN);

--- a/src/state/sessions.js
+++ b/src/state/sessions.js
@@ -1,0 +1,15 @@
+const LRU = require('lru-cache');
+
+const activeTrivia = new LRU({
+  max: 1000,
+  ttl: 60 * 1000, // 1 minute
+  updateAgeOnGet: true,
+});
+
+const searchSessions = new LRU({
+  max: 1000,
+  ttl: 5 * 60 * 1000, // 5 minutes
+  updateAgeOnGet: true,
+});
+
+module.exports = { activeTrivia, searchSessions };


### PR DESCRIPTION
## Summary
- centralize trivia and search session tracking with `lru-cache`
- refactor trivia and search commands to consume shared caches
- clear sessions when source messages are deleted

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b53552f0f48324ae9202fc7535f62d