### PR TITLE
refactor: use p helpers for db queries

### DIFF
--- a/src/commands/brlex.js
+++ b/src/commands/brlex.js
@@ -1,5 +1,12 @@
-const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+const {
+  SlashCommandBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+} = require('discord.js');
 const { createAdapter } = require('../db/translations');
+const { pall } = require('../db/p');
 const { idToName } = require('../lib/books');
 const strongsDict = require('../../db/strongs-dictionary.json');
 
@@ -31,12 +38,7 @@ async function findVersesByStrong(strong, page = 0, pageSize = PAGE_SIZE, transl
     const offset = page * pageSize;
     const sql = `SELECT ${c.book} AS book, ${c.chapter} AS chapter, ${c.verse} AS verse, ${c.text} AS text FROM verses WHERE ${c.text} LIKE ? ORDER BY ${c.book}, ${c.chapter}, ${c.verse} LIMIT ? OFFSET ?`;
     const pattern = `%{${strong}}%`;
-    const rows = await new Promise((resolve, reject) => {
-      adapter._db.all(sql, [pattern, pageSize + 1, offset], (err, res) => {
-        if (err) reject(err);
-        else resolve(res);
-      });
-    });
+    const rows = await pall(adapter._db, sql, [pattern, pageSize + 1, offset]);
     adapter.close();
     return rows;
   }

--- a/src/interaction/contextButtons.js
+++ b/src/interaction/contextButtons.js
@@ -1,5 +1,6 @@
 const { openReadingAdapter } = require('../db/openReading');
 const { createAdapter } = require('../db/translations');
+const { pall } = require('../db/p');
 const { idToName } = require('../lib/books');
 const { unpack } = require('../ui/contextRow');
 const strongsDict = require('../../db/strongs-dictionary.json');
@@ -15,18 +16,10 @@ const STRONGS_TRANSLATIONS = {
 async function findXrefs(adapter, strongs, exclude) {
   const c = adapter._cols;
 
-  function all(sql, params) {
-    return new Promise((resolve, reject) => {
-      adapter._db.all(sql, params, (err, rows) =>
-        err ? reject(err) : resolve(rows)
-      );
-    });
-  }
-
   const counts = new Map();
   for (const strong of strongs) {
     const sql = `SELECT ${c.book} AS book, ${c.chapter} AS chapter, ${c.verse} AS verse FROM verses WHERE ${c.text} LIKE ?`;
-    const rows = await all(sql, [`%<${strong}>%`]);
+    const rows = await pall(adapter._db, sql, [`%<${strong}>%`]);
     for (const r of rows) {
       if (r.book === exclude.book && r.chapter === exclude.chapter && r.verse === exclude.verse) continue;
       const key = `${r.book}:${r.chapter}:${r.verse}`;

--- a/src/search/searchSmart.js
+++ b/src/search/searchSmart.js
@@ -24,15 +24,15 @@ async function searchSmart(adapter, rawQuery, limit = 10) {
           const row = await adapter.getVerse(book, chapter, verses[0]);
           return row ? [row] : [];
         }
-        return adapter.getVersesSubset(book, chapter, verses);
+        return await adapter.getVersesSubset(book, chapter, verses);
       }
-      return adapter.getChapter(book, chapter);
+      return await adapter.getChapter(book, chapter);
     }
   }
 
   const safe = ftsSafeQuery(query);
   if (!safe) return [];
-  return adapter.search(safe, limit);
+  return await adapter.search(safe, limit);
 }
 
 module.exports = searchSmart;


### PR DESCRIPTION
## Summary
- use shared pall helper for verse cross-reference lookups and lexical query
- await adapter methods during smart scripture search for consistent promise handling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5917724e48324b253d52f0fbde5af