### PR TITLE
feat: add plan normalization utilities

### DIFF
--- a/src/lib/plan-normalize.js
+++ b/src/lib/plan-normalize.js
@@ -1,0 +1,79 @@
+const { toReading } = require('./parseRef');
+const { idToName } = require('./books');
+
+function normalizeReading(input) {
+  if (!input) return null;
+  if (typeof input === 'string') {
+    return toReading(input);
+  }
+  if (typeof input === 'object') {
+    const { ref, book, ranges, chapter, verses, ...meta } = input;
+    const spec = ref !== undefined ? ref : { book, ranges, chapter, verses };
+    const reading = toReading(spec);
+    if (!reading) return null;
+    return { ...reading, ...meta };
+  }
+  return null;
+}
+
+function normalizeDay(day) {
+  if (day === undefined || day === null) return { readings: [] };
+  if (typeof day === 'string') {
+    return { readings: [normalizeReading(day)] };
+  }
+  if (Array.isArray(day)) {
+    return { readings: day.map(normalizeReading) };
+  }
+  if (typeof day === 'object') {
+    if ('readings' in day || '_meta' in day) {
+      const { readings = [], _meta } = day;
+      const norm = { readings: readings.map(normalizeReading) };
+      if (_meta !== undefined) norm._meta = _meta;
+      return norm;
+    }
+    return { readings: [normalizeReading(day)] };
+  }
+  return { readings: [] };
+}
+
+function normalizeDays(days) {
+  if (!Array.isArray(days)) return [];
+  return days.map(normalizeDay);
+}
+
+function formatReading(reading) {
+  if (!reading) return '';
+  const bookName = idToName(reading.book) || '';
+  const segments = [];
+  for (const r of reading.ranges || []) {
+    if (r.verses && r.verses.length) {
+      const verses = [];
+      const vs = [...r.verses].sort((a, b) => a - b);
+      let start = vs[0];
+      let prev = vs[0];
+      for (let i = 1; i <= vs.length; i++) {
+        const v = vs[i];
+        if (v === prev + 1) {
+          prev = v;
+          continue;
+        }
+        if (start === prev) verses.push(String(start));
+        else verses.push(`${start}-${prev}`);
+        start = v;
+        prev = v;
+      }
+      segments.push(`${r.chapter}:${verses.join(',')}`);
+    } else {
+      segments.push(String(r.chapter));
+    }
+  }
+  const ref = `${bookName} ${segments.join(';')}`.trim();
+  return reading.title ? `${reading.title}: ${ref}` : ref;
+}
+
+function formatDay(day) {
+  const readings = Array.isArray(day.readings) ? day.readings : [];
+  return readings.map((r) => `• ${formatReading(r)}`).join('\n');
+}
+
+module.exports = { normalizeDays, formatReading, formatDay };

--- a/test/plan-normalize.test.js
+++ b/test/plan-normalize.test.js
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { normalizeDays, formatReading, formatDay } = require('../src/lib/plan-normalize');
+
+// Test normalization for simple string days
+const days1 = normalizeDays(['Genesis 1']);
+test('normalizeDays handles string input', () => {
+  assert.deepEqual(days1, [
+    { readings: [{ book:1, ranges:[{ chapter:1 }] }] }
+  ]);
+});
+
+// Test normalization for array of readings
+const days2 = normalizeDays([[ 'Genesis 1', 'Exodus 2' ]]);
+test('normalizeDays handles array of readings', () => {
+  assert.deepEqual(days2, [
+    { readings: [
+      { book:1, ranges:[{ chapter:1 }] },
+      { book:2, ranges:[{ chapter:2 }] }
+    ] }
+  ]);
+});
+
+// Test structured object with metadata and day-level _meta
+const days3 = normalizeDays([
+  {
+    readings: [
+      { ref: 'John 3:16', title: 'Memory', note: 'For God so loved', translation: 'NIV' },
+      'Genesis 1'
+    ],
+    _meta: { mood: 'happy' }
+  }
+]);
+
+test('normalizeDays preserves metadata and day-level _meta', () => {
+  assert.deepEqual(days3, [
+    {
+      readings: [
+        { book:43, ranges:[{ chapter:3, verses:[16] }], title:'Memory', note:'For God so loved', translation:'NIV' },
+        { book:1, ranges:[{ chapter:1 }] }
+      ],
+      _meta: { mood: 'happy' }
+    }
+  ]);
+});
+
+// Test formatting utilities
+const formattedReading = formatReading({ book:43, ranges:[{ chapter:3, verses:[1,2,3,5,7,8] }] });
+
+test('formatReading compacts verse ranges', () => {
+  assert.equal(formattedReading, 'John 3:1-3,5,7-8');
+});
+
+const dayForFormat = { readings: [
+  { book:43, ranges:[{ chapter:3, verses:[16,17] }] },
+  { book:1, ranges:[{ chapter:1 }] }
+] };
+
+test('formatDay bulletizes readings', () => {
+  assert.equal(formatDay(dayForFormat), '• John 3:16-17\n• Genesis 1');
+});


### PR DESCRIPTION
## Summary
- add plan normalization helpers to convert days and format readings
- support reading metadata and day-level meta
- test plan normalization and formatting

## Testing
- `node --test` *(fails: brsearch text paginates long results, brsearch topic groups results by book)*

------
https://chatgpt.com/codex/tasks/task_e_68b623c732a4832482c7c49a191da52a