### PR TITLE
Format plan DMs with normalized readings

### DIFF
--- a/test/brsearch.test.js
+++ b/test/brsearch.test.js
@@ -39,7 +39,8 @@ test('brsearch text paginates long results', async () => {
 
   await brsearch.execute(interaction);
 
-  assert.ok(reply.content.length <= 2000);
+  const desc = reply.embeds[0]?.data?.description || '';
+  assert.ok(desc.length <= 4096);
   assert.ok(reply.components.length > 0);
 });
 
@@ -78,7 +79,8 @@ test('brsearch topic groups results by book', async () => {
 
   await brsearch.execute(interaction);
 
-  assert.ok(/Genesis/.test(reply.content));
-  assert.ok(/Exodus/.test(reply.content));
+  const desc = reply.embeds[0]?.data?.description || '';
+  assert.ok(/Genesis/.test(desc));
+  assert.ok(/Exodus/.test(desc));
 });
 

--- a/test/plans-db.test.js
+++ b/test/plans-db.test.js
@@ -11,11 +11,16 @@ const db = open(dbPath);
 const planId = 'roundtrip-test';
 const userId = 'u1';
 const days = [
-  [{ book: 1, ranges: [{ chapter: 1 }] }],
-  [{ book: 1, ranges: [{ chapter: 2 }] }],
+  { readings: [{ book: 1, ranges: [{ chapter: 1 }] }] },
+  {
+    readings: [
+      { book: 1, ranges: [{ chapter: 2 }] },
+      { book: 2, ranges: [{ chapter: 3 }] },
+    ],
+  },
 ];
 
-test('plans DB round-trip with normalized days', async (t) => {
+test('plans DB round-trip with normalized multi-reading days', async (t) => {
   await getAllPlanDefs();
   await prun(
     db,


### PR DESCRIPTION
## Summary
- Format reading-plan DMs using `formatDay`, including optional `_meta.title`
- Report total normalized days when starting and completing plans
- Extend plan DB tests for days containing multiple readings and update brsearch tests for embed responses

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b6327dd5c88324aa17d53c7d5246b8