### PR TITLE
Format plan scheduler messages with bullet lists

### DIFF
--- a/scheduler/planScheduler.js
+++ b/scheduler/planScheduler.js
@@ -1,10 +1,6 @@
 const cron = require('node-cron');
-const {
-  getAllUserPlans,
-  getPlanDef,
-  updateLastNotified,
-  resetStreak,
-} = require('../src/db/plans');
+const plansDb = require('../src/db/plans');
+const { formatDay } = require('../src/lib/plan-normalize');
 
 function today() {
   return new Date().toISOString().slice(0, 10);
@@ -17,20 +13,33 @@ function yesterday() {
 let job;
 
 async function checkPlans(client) {
-  const plans = await getAllUserPlans();
+  const plans = await plansDb.getAllUserPlans();
   const todayStr = today();
   const yest = yesterday();
   for (const p of plans) {
     if (p.last_notified === todayStr) continue;
-    const plan = await getPlanDef(p.plan_id);
-    const reading = plan.days[p.day];
-    if (!reading) continue;
+    const plan = await plansDb.getPlanDef(p.plan_id);
+    const dayReadings = plan.days[p.day];
+    if (!dayReadings) continue;
     try {
       const user = await client.users.fetch(p.user_id);
-      await user.send(`Day ${p.day + 1}: ${reading}`);
-      await updateLastNotified(p.user_id, todayStr);
+      const title = dayReadings._meta && dayReadings._meta.title;
+      let body = `Day ${p.day + 1}${title ? `: ${title}` : ':'}\n${formatDay(dayReadings)}`;
+      if (dayReadings._meta) {
+        const meta = { ...dayReadings._meta };
+        delete meta.title;
+        if (meta.note) {
+          body += `\nNote: ${meta.note}`;
+          delete meta.note;
+        }
+        for (const [k, v] of Object.entries(meta)) {
+          body += `\n${k}: ${v}`;
+        }
+      }
+      await user.send(body);
+      await plansDb.updateLastNotified(p.user_id, todayStr);
       if (p.last_completed !== yest) {
-        await resetStreak(p.user_id);
+        await plansDb.resetStreak(p.user_id);
       }
     } catch (err) {
       console.error('Failed to DM reading:', err);
@@ -45,4 +54,4 @@ function setupPlanScheduler(client) {
   });
 }
 
-module.exports = { setupPlanScheduler };
+module.exports = { setupPlanScheduler, checkPlans };

--- a/test/planScheduler.test.js
+++ b/test/planScheduler.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const plansDb = require('../src/db/plans');
+const { checkPlans } = require('../scheduler/planScheduler');
+
+function yest() {
+  return new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+}
+
+test('checkPlans formats readings with bullets and metadata', async () => {
+  const todayStr = new Date().toISOString().slice(0, 10);
+  const dayObj = {
+    readings: [
+      { book: 1, ranges: [{ chapter: 1 }] },
+      { book: 2, ranges: [{ chapter: 3, verses: [16, 17] }] },
+    ],
+    _meta: { title: 'Start', note: 'Remember to pray' },
+  };
+
+  test.mock.method(plansDb, 'getAllUserPlans', async () => [
+    { user_id: 'u1', plan_id: 'p1', day: 0, last_notified: null, last_completed: yest() },
+  ]);
+  test.mock.method(plansDb, 'getPlanDef', async () => ({ days: [dayObj] }));
+  const upd = [];
+  test.mock.method(plansDb, 'updateLastNotified', async (id, date) => {
+    upd.push({ id, date });
+  });
+  test.mock.method(plansDb, 'resetStreak', async () => {});
+
+  const sent = [];
+  const client = {
+    users: {
+      fetch: async () => ({
+        send: async (msg) => {
+          sent.push(msg);
+        },
+      }),
+    },
+  };
+
+  await checkPlans(client);
+
+  assert.equal(sent.length, 1);
+  assert.match(sent[0], /^Day 1: Start/);
+  assert.match(sent[0], /• Genesis 1/);
+  assert.match(sent[0], /• Exodus 3:16-17/);
+  assert.match(sent[0], /Note: Remember to pray/);
+  assert.equal(upd.length, 1);
+  assert.equal(upd[0].date, todayStr);
+
+  test.mock.reset();
+});


### PR DESCRIPTION
## Summary
- Format reading plan notifications with bulleted readings and day metadata.
- Add scheduler unit test verifying formatted output and update tracking.

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b6347bae708324a07ccc52cea47eac