### PR TITLE
Support optional plan metadata

### DIFF
--- a/docs/plan-metadata.md
+++ b/docs/plan-metadata.md
@@ -1,0 +1,53 @@
+# Reading Plan Metadata
+
+`normalizeDays` converts raw plan definitions into a normalized form. Each day contains an array of `Reading` objects and optional metadata in a `_meta` object. Both readings and `_meta` support the following optional fields:
+
+- `title`
+- `note`
+- `prayer`
+- `discussion`
+- `translation`
+- `image`
+- `link`
+- `tags`
+
+## Example
+
+```json
+{
+  "readings": [
+    {
+      "ref": "John 3:16",
+      "title": "Memory Verse",
+      "note": "For God so loved",
+      "prayer": "Thank you for Your love",
+      "translation": "NIV",
+      "image": "https://example.com/john316.png",
+      "link": "https://bible.example/john3-16",
+      "tags": ["gospel", "love"]
+    }
+  ],
+  "_meta": {
+    "title": "The Gospel",
+    "note": "Focus on God's love today",
+    "prayer": "Pray for your community",
+    "discussion": "Share what this verse means to you",
+    "link": "https://devotional.example/gospel",
+    "tags": ["core", "salvation"]
+  }
+}
+```
+
+`formatDay` renders these fields when present:
+
+```
+Day 1: The Gospel
+• John 3:16 (NIV)
+  Note: For God so loved
+  Prayer: Thank you for Your love
+Note: Focus on God's love today
+Prayer: Pray for your community
+Discussion: Share what this verse means to you
+Link: https://devotional.example/gospel
+Tags: core, salvation
+```

--- a/scheduler/planScheduler.js
+++ b/scheduler/planScheduler.js
@@ -25,17 +25,6 @@ async function checkPlans(client) {
       const user = await client.users.fetch(p.user_id);
       const title = dayReadings._meta && dayReadings._meta.title;
       let body = `Day ${p.day + 1}${title ? `: ${title}` : ':'}\n${formatDay(dayReadings)}`;
-      if (dayReadings._meta) {
-        const meta = { ...dayReadings._meta };
-        delete meta.title;
-        if (meta.note) {
-          body += `\nNote: ${meta.note}`;
-          delete meta.note;
-        }
-        for (const [k, v] of Object.entries(meta)) {
-          body += `\n${k}: ${v}`;
-        }
-      }
       await user.send(body);
       await plansDb.updateLastNotified(p.user_id, todayStr);
       if (p.last_completed !== yest) {

--- a/test/plan-normalize.test.js
+++ b/test/plan-normalize.test.js
@@ -25,22 +25,55 @@ test('normalizeDays handles array of readings', () => {
 const days3 = normalizeDays([
   {
     readings: [
-      { ref: 'John 3:16', title: 'Memory', note: 'For God so loved', translation: 'NIV' },
-      'Genesis 1'
+      {
+        ref: 'John 3:16',
+        title: 'Memory',
+        note: 'For God so loved',
+        prayer: 'Thank you',
+        translation: 'NIV',
+        image: 'http://img',
+        link: 'http://link',
+        tags: ['gospel'],
+        extra: 'ignored',
+      },
+      'Genesis 1',
     ],
-    _meta: { mood: 'happy' }
-  }
+    _meta: {
+      title: 'Day title',
+      note: 'Day note',
+      prayer: 'Day prayer',
+      discussion: 'Talk',
+      link: 'http://day',
+      mood: 'happy',
+    },
+  },
 ]);
 
-test('normalizeDays preserves metadata and day-level _meta', () => {
+test('normalizeDays filters metadata and day-level _meta', () => {
   assert.deepEqual(days3, [
     {
       readings: [
-        { book:43, ranges:[{ chapter:3, verses:[16] }], title:'Memory', note:'For God so loved', translation:'NIV' },
-        { book:1, ranges:[{ chapter:1 }] }
+        {
+          book: 43,
+          ranges: [{ chapter: 3, verses: [16] }],
+          title: 'Memory',
+          note: 'For God so loved',
+          prayer: 'Thank you',
+          translation: 'NIV',
+          image: 'http://img',
+          link: 'http://link',
+          tags: ['gospel'],
+        },
+        { book: 1, ranges: [{ chapter: 1 }] },
       ],
-      _meta: { mood: 'happy' }
-    }
+      _meta: {
+        title: 'Day title',
+        note: 'Day note',
+        prayer: 'Day prayer',
+        discussion: 'Talk',
+        link: 'http://day',
+      },
+    },
   ]);
 });
 
@@ -51,11 +84,16 @@ test('formatReading compacts verse ranges', () => {
   assert.equal(formattedReading, 'John 3:1-3,5,7-8');
 });
 
-const dayForFormat = { readings: [
-  { book:43, ranges:[{ chapter:3, verses:[16,17] }] },
-  { book:1, ranges:[{ chapter:1 }] }
-] };
+const dayForFormat = {
+  readings: [
+    { book: 43, ranges: [{ chapter: 3, verses: [16, 17] }], note: 'Key', translation: 'NIV' },
+  ],
+  _meta: { note: 'Day note' },
+};
 
-test('formatDay bulletizes readings', () => {
-  assert.equal(formatDay(dayForFormat), '• John 3:16-17\n• Genesis 1');
+test('formatDay renders metadata', () => {
+  assert.equal(
+    formatDay(dayForFormat),
+    '• John 3:16-17 (NIV)\n  Note: Key\nNote: Day note'
+  );
 });


### PR DESCRIPTION
## Summary
- Support title, note, prayer, discussion, translation, image, link and tags in normalized readings and day metadata
- Render optional metadata in formatted day output and simplify scheduler
- Document plan metadata schema with examples

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b635a36cbc8324baa3f8d938f4309e