### PR TITLE
Add CLI entry point to seed plans

### DIFF
--- a/src/boot/seedPlans.js
+++ b/src/boot/seedPlans.js
@@ -38,3 +38,10 @@ async function seed() {
 }
 
 module.exports = { seed };
+
+if (require.main === module) {
+  seed().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- execute seeding from `seedPlans.js` when run directly

## Testing
- `npm test` *(fails: Missing script "test")*
- `node src/boot/seedPlans.js`


------
https://chatgpt.com/codex/tasks/task_e_68b652f418d88324ba73c0cdfe5530e9