### PR TITLE
Seed plans from JSON files with upsert support

### DIFF
--- a/src/boot/seedPlans.js
+++ b/src/boot/seedPlans.js
@@ -1,46 +1,66 @@
 const fs = require('fs');
 const path = require('path');
-const { normalizeDays } = require('../lib/plan-normalize');
+const plansDb = require('../db/plans');
+const { normalizePlan } = require('../lib/plan-normalize');
 
-async function seedPlan(id, plan) {
-  const planDefsPath = path.join(__dirname, '..', '..', 'plan_defs.json');
-  let plans = [];
+async function loadJson(file) {
   try {
-    const content = await fs.promises.readFile(planDefsPath, 'utf8');
-    plans = JSON.parse(content);
+    const data = await fs.promises.readFile(file, 'utf8');
+    return JSON.parse(data);
   } catch (err) {
-    if (err.code !== 'ENOENT') throw err;
-  }
-  if (!plans.find(p => p.id === id)) {
-    const days = normalizeDays(plan.days);
-    plans.push({ id, ...plan, days });
-    await fs.promises.writeFile(planDefsPath, JSON.stringify(plans, null, 2));
+    if (err.code !== 'ENOENT') {
+      const msg = err instanceof SyntaxError ? 'Malformed JSON' : err.message;
+      console.error(`${msg}: ${file}`);
+    }
+    return null;
   }
 }
 
-async function seed() {
-  const plan = {
-    name: 'John 3-Day Plan',
-    description: 'Demonstrates complex plan structures',
-    days: [
-      'John 1',
-      ['John 2', 'John 3'],
-      {
-        readings: [
-          { book: 'John', chapter: 4, verses: [4, 5, 6], title: 'At the well' },
-          { ref: 'John 4:7-10', note: 'Conversation' }
-        ],
-        _meta: { topic: 'Living water' }
+async function gatherPlans() {
+  const root = path.join(__dirname, '..', '..');
+  const plansDir = path.join(root, 'plans');
+  const planDefsFile = path.join(root, 'plan_defs.json');
+  const plans = [];
+
+  const defs = await loadJson(planDefsFile);
+  if (Array.isArray(defs)) plans.push(...defs);
+
+  try {
+    const entries = await fs.promises.readdir(plansDir);
+    for (const f of entries.filter((e) => e.endsWith('.json'))) {
+      const plan = await loadJson(path.join(plansDir, f));
+      if (plan) {
+        if (!plan.id) plan.id = path.basename(f, '.json');
+        plans.push(plan);
       }
-    ],
-  };
-  await seedPlan('j3', plan);
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') console.error(`Failed reading plans dir: ${err.message}`);
+  }
+  return plans;
 }
 
-module.exports = { seed };
+async function seedAll() {
+  const plans = await gatherPlans();
+  let inserted = 0;
+  let updated = 0;
+  for (const plan of plans) {
+    try {
+      const norm = normalizePlan(plan);
+      const res = await plansDb.upsertPlanDef(norm);
+      if (res === 'updated') updated++;
+      else inserted++;
+    } catch (err) {
+      console.error(`Failed to upsert plan ${plan.id}:`, err);
+    }
+  }
+  console.log(`Inserted ${inserted} plans, updated ${updated} plans`);
+}
+
+module.exports = { seedAll };
 
 if (require.main === module) {
-  seed().catch(err => {
+  seedAll().catch((err) => {
     console.error(err);
     process.exit(1);
   });

--- a/src/db/plans.js
+++ b/src/db/plans.js
@@ -138,6 +138,19 @@ async function resetStreak(userId) {
   await prun(db, 'UPDATE user_plans SET streak = 0 WHERE user_id = ?', [userId]);
 }
 
+async function upsertPlanDef(plan) {
+  await init;
+  const { id, name, description = '', days = [] } = plan;
+  const exists = await pget(db, 'SELECT 1 FROM plan_defs WHERE id = ?', [id]);
+  await prun(
+    db,
+    `INSERT INTO plan_defs (id, name, description, days) VALUES (?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET name=excluded.name, description=excluded.description, days=excluded.days`,
+    [id, name, description, JSON.stringify(days)]
+  );
+  return exists ? 'updated' : 'inserted';
+}
+
 module.exports = {
   getAllPlanDefs,
   getPlanDef,
@@ -148,4 +161,5 @@ module.exports = {
   resetStreak,
   getUserPlan,
   stopPlan,
+  upsertPlanDef,
 };

--- a/src/lib/plan-normalize.js
+++ b/src/lib/plan-normalize.js
@@ -66,6 +66,11 @@ function normalizeDays(days) {
   return days.map(normalizeDay);
 }
 
+function normalizePlan(plan = {}) {
+  const { days, ...rest } = plan;
+  return { ...rest, days: normalizeDays(days) };
+}
+
 function formatReading(reading) {
   if (!reading) return '';
   const bookName = idToName(reading.book) || '';
@@ -124,4 +129,4 @@ function formatDay(day) {
   return lines.join('\n');
 }
 
-module.exports = { normalizeDays, formatReading, formatDay };
+module.exports = { normalizeDays, normalizePlan, formatReading, formatDay };


### PR DESCRIPTION
## Summary
- add plan seeding utility loading plan_defs.json and plans/*.json
- expose normalizePlan helper and DB upsertPlanDef

## Testing
- `npm test` (fails: Missing script)
- `node --test test/planScheduler.test.js`
- `node src/boot/seedPlans.js`

------
https://chatgpt.com/codex/tasks/task_e_68b656d45bc8832481f2268731e800c4