### PR TITLE
Add optional seedPlans bootstrap

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ const { handleButtons: handleSearchButtons } = require("./commands/brsearch");
 const { ephemeral } = require("./src/utils/ephemeral");
 const { activeTrivia, searchSessions } = require('./src/state/sessions');
 
+try { require('./src/boot/seedPlans').seedAll(); }
+catch (e) { console.warn('[seedPlans] skipped:', e.message); }
+
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,


### PR DESCRIPTION
## Summary
- Attempt to seed reading plans at startup, skipping when module is missing

## Testing
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_68b65c6d825083249d27fd862bac294b