### PR TITLE
Add /brsurprise random verse command

### DIFF
--- a/commands/brsurprise.js
+++ b/commands/brsurprise.js
@@ -1,0 +1,78 @@
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+const { getUserTranslation } = require('../src/db/user-prefs');
+const { openReading } = require('../src/db/openReading');
+const { idToName } = require('../src/lib/books');
+
+const BTN_MORE = 'brs:m'; // short customId
+
+async function drawRandom(translationPref) {
+  const adapter = await openReading(translationPref); // prefers plain, falls back to strongs+strip
+  try {
+    const row = await adapter.getRandom();
+    return row; // {book, chapter, verse, text}
+  } finally {
+    if (adapter && adapter.close) adapter.close();
+  }
+}
+
+function buildEmbed(row, humanTrans, pageTag = '') {
+  const ref = `${idToName(row.book)} ${row.chapter}:${row.verse}`;
+  const title = pageTag ? `Random Verse ${pageTag}` : 'Random Verse';
+  return new EmbedBuilder()
+    .setTitle(title)
+    .setDescription(`**${ref}** — ${row.text}`)
+    .setFooter({ text: humanTrans.toUpperCase() });
+}
+
+function buildRow() {
+  return new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId(BTN_MORE).setLabel('Another').setStyle(ButtonStyle.Secondary)
+  );
+}
+
+module.exports.data = new SlashCommandBuilder()
+  .setName('brsurprise')
+  .setDescription('Get a random Bible verse')
+  .addStringOption(opt =>
+    opt.setName('translation')
+      .setDescription('Force translation (default: your preference)')
+      .addChoices({ name: 'ASV', value: 'asv' }, { name: 'KJV', value: 'kjv' })
+  );
+
+module.exports.execute = async (interaction) => {
+  await interaction.deferReply();
+  const forced = (interaction.options.getString('translation') || '').toLowerCase();
+  let userPref = await getUserTranslation(interaction.user.id);
+  if (userPref === 'asvs') userPref = 'asv';
+  if (userPref === 'kjv_strongs') userPref = 'kjv';
+  const t = forced || userPref || 'asv';
+
+  const row = await drawRandom(t);
+  if (!row) return interaction.editReply({ content: 'No verse available.', flags: 64 });
+
+  const embed = buildEmbed(row, t);
+  await interaction.editReply({ content: null, embeds: [embed], components: [buildRow()] });
+};
+
+module.exports.handleButtons = async (interaction) => {
+  if (!interaction.isButton() || interaction.customId !== BTN_MORE) return false;
+
+  // try to recover the translation label from footer; if missing, fall back to user pref
+  const prevFooter = interaction.message?.embeds?.[0]?.footer?.text?.toLowerCase();
+  const fromEmbed = (prevFooter === 'asv' || prevFooter === 'kjv') ? prevFooter : null;
+
+  let userPref = await getUserTranslation(interaction.user.id);
+  if (userPref === 'asvs') userPref = 'asv';
+  if (userPref === 'kjv_strongs') userPref = 'kjv';
+  const t = fromEmbed || userPref || 'asv';
+
+  const row = await drawRandom(t);
+  if (!row) {
+    await interaction.reply({ content: 'No verse available.', flags: 64 });
+    return true;
+  }
+  const pageTag = '(another)';
+  const embed = buildEmbed(row, t, pageTag);
+  await interaction.update({ content: null, embeds: [embed], components: [buildRow()] });
+  return true;
+};

--- a/index.js
+++ b/index.js
@@ -7,9 +7,6 @@ const { setupDailyVerse } = require("./scheduler/dailyVerseScheduler"); // Corre
 const { setupPlanScheduler } = require("./scheduler/planScheduler");
 const handleAutocomplete = require("./src/interaction/autocomplete");
 const handleContextButtons = require("./src/interaction/contextButtons");
-const { handleButtons: handleTriviaButtons } = require("./src/commands/brtrivia");
-const { handleButtons: handleLexButtons } = require("./src/commands/brlex");
-const { handleButtons: handleSearchButtons } = require("./commands/brsearch");
 const { ephemeral } = require("./src/utils/ephemeral");
 const { activeTrivia, searchSessions } = require('./src/state/sessions');
 
@@ -104,13 +101,16 @@ client.on("interactionCreate", async (interaction) => {
       );
     }
   } else if (interaction.isButton()) {
-    const searchHandled = await handleSearchButtons(interaction);
-    if (searchHandled) return;
-    const triviaHandled = await handleTriviaButtons(interaction);
-    if (triviaHandled) return;
-    const lexHandled = await handleLexButtons(interaction);
-    if (lexHandled) return;
-    // Attempt to handle context-specific buttons before other handlers
+    for (const cmd of client.commands.values()) {
+      if (typeof cmd.handleButtons === 'function') {
+        try {
+          const handled = await cmd.handleButtons(interaction);
+          if (handled) return;
+        } catch (err) {
+          console.error('Error in command button handler:', err);
+        }
+      }
+    }
     const contextHandled = await handleContextButtons(interaction);
     if (contextHandled) return;
 

--- a/src/db/openReading.js
+++ b/src/db/openReading.js
@@ -35,6 +35,10 @@ async function openReading(translation = 'asv', options = {}) {
           return r;
         });
       },
+      getRandom: async () => {
+        const row = await adapter.getRandom();
+        return row ? { ...row, text: stripStrongs(row.text) } : null;
+      },
       close: () => adapter.close(),
       _db: adapter._db,
       _cols: adapter._cols,


### PR DESCRIPTION
## Summary
- add getRandom() to translation adapters with Strong's fallback support
- introduce /brsurprise slash command returning random verse with "Another" button
- route button interactions through command handlers automatically

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b6824c98308324b27c00ab8633f056