### PR TITLE
feat: add safeReply helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const { setupPlanScheduler } = require("./scheduler/planScheduler");
 const handleAutocomplete = require("./src/interaction/autocomplete");
 const handleContextButtons = require("./src/interaction/contextButtons");
 const { ephemeral } = require("./src/utils/ephemeral");
+const { safeReply } = require("./src/utils/safeReply");
 const { activeTrivia, searchSessions } = require('./src/state/sessions');
 
 try { require('./src/boot/seedPlans').seedAll(); }
@@ -87,16 +88,20 @@ client.on("interactionCreate", async (interaction) => {
   if (interaction.isChatInputCommand()) {
     const command = client.commands.get(interaction.commandName);
     if (!command) {
-      await interaction.reply(ephemeral({
-        content: "Unknown command.",
-      }));
+      await safeReply(
+        interaction,
+        ephemeral({
+          content: "Unknown command.",
+        })
+      );
       return;
     }
     try {
       await command.execute(interaction);
     } catch (error) {
       console.error("Error executing command:", error);
-      await interaction.reply(
+      await safeReply(
+        interaction,
         ephemeral({ content: "There was an error while executing this command!" })
       );
     }
@@ -117,7 +122,8 @@ client.on("interactionCreate", async (interaction) => {
     const handler = client.buttons.get(interaction.customId);
     if (!handler) {
       try {
-        await interaction.reply(
+        await safeReply(
+          interaction,
           ephemeral({ content: "Unknown button interaction." })
         );
       } catch (err) {
@@ -129,11 +135,10 @@ client.on("interactionCreate", async (interaction) => {
       await handler.execute(interaction);
     } catch (error) {
       console.error(`Error executing button handler ${interaction.customId}:`, error);
-      if (!interaction.replied) {
-        await interaction.reply(
-          ephemeral({ content: "There was an error while executing this action!" })
-        );
-      }
+      await safeReply(
+        interaction,
+        ephemeral({ content: "There was an error while executing this action!" })
+      );
     }
   }
 });

--- a/src/utils/safeReply.js
+++ b/src/utils/safeReply.js
@@ -1,0 +1,8 @@
+async function safeReply(interaction, data) {
+  if (interaction.deferred || interaction.replied) {
+    return interaction.editReply(data);
+  }
+  return interaction.reply(data);
+}
+
+module.exports = { safeReply };


### PR DESCRIPTION
## Summary
- add `safeReply` utility to safely edit or send replies
- use `safeReply` for all interaction error responses

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b6ff5edc30832486e1932baff17a6c