### PR TITLE
Log Discord client errors and unhandled rejections

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,14 @@ async function onClientReady(client) {
 client.once("clientReady", onClientReady);
 client.once("ready", onClientReady);
 
+client.on('error', (error) => {
+  console.error('Discord client error:', error);
+});
+
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled promise rejection:', reason);
+});
+
 client.on("interactionCreate", async (interaction) => {
   if (interaction.isAutocomplete()) {
     try {


### PR DESCRIPTION
## Summary
- Log Discord client errors via `client.on('error')`.
- Capture unhandled promise rejections with `process.on('unhandledRejection')` for visibility.

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b702119fcc8324a2dbfa293fc397ca