### PR TITLE
feat: log opened database

### DIFF
--- a/src/db/translations.js
+++ b/src/db/translations.js
@@ -15,6 +15,7 @@ async function createAdapter(translation = 'asv', options = {}) {
   if (!file) throw new Error(`Unknown translation: ${translation}`);
   const dbPath = path.join(__dirname, '..', '..', 'db', file);
   const db = open(dbPath);
+  console.log(`[db] opened ${translation} at ${dbPath}`);
   const state = { db, columns: null, hasFts: false, stripStrongs: !!options.stripStrongs };
   await introspect(state);
   await ensureLocIndex(state);


### PR DESCRIPTION
## Summary
- log translation database path when opened

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7035e6f008324907d0a7180f35c01