### PR TITLE
Ensure sequential adapter opening and fallback handling

### DIFF
--- a/src/db/openReading.js
+++ b/src/db/openReading.js
@@ -1,5 +1,5 @@
 const { createAdapter } = require('./translations');
-const { STRONGS_REGEX, stripStrongs } = require('./strongs');
+const { stripStrongs } = require('./strongs');
 
 const STRONGS_FALLBACK = {
   kjv: 'kjv_strongs',
@@ -8,7 +8,8 @@ const STRONGS_FALLBACK = {
 
 async function openReading(translation = 'asv', options = {}) {
   try {
-    return await createAdapter(translation, options);
+    const adapter = await createAdapter(translation, options);
+    return adapter;
   } catch (err) {
     const strongs = STRONGS_FALLBACK[translation];
     if (!strongs) throw err;
@@ -51,7 +52,7 @@ async function openReadingAdapter(preferred = 'asv', options = {}) {
     return await openReading(preferred, options);
   } catch (err) {
     const fallback = preferred === 'kjv' ? 'asv' : 'kjv';
-    return openReading(fallback, options);
+    return await openReading(fallback, options);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure openReading returns adapter from awaited createAdapter
- await fallback adapter creation to avoid multiple open DB adapters

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test` *(fails: 5 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b704578e548324bee7dda07c8ec0b8