### PR TITLE
Add verse-expanding plan formatter and update scheduling

### DIFF
--- a/src/commands/brlex.js
+++ b/src/commands/brlex.js
@@ -60,7 +60,6 @@ async function findVersesByStrong(arg1, arg2, arg3 = 0, arg4 = PAGE_SIZE) {
     const sql = `SELECT ${c.book} AS book, ${c.chapter} AS chapter, ${c.verse} AS verse, ${c.text} AS text FROM verses WHERE ${c.text} LIKE ? ORDER BY ${c.book}, ${c.chapter}, ${c.verse} LIMIT ? OFFSET ?`;
     const pattern = `%{${strong}}%`;
     const rows = await pall(adapter._db, sql, [pattern, pageSize + 1, offset]);
-    adapter.close();
     return rows;
   }
 

--- a/src/lib/plan-format-text.js
+++ b/src/lib/plan-format-text.js
@@ -1,0 +1,97 @@
+const { openReading } = require('../db/openReading');
+const { idToName } = require('./books');
+
+function compactRanges(verses = []) {
+  if (!verses.length) return '';
+  const sorted = [...verses].sort((a, b) => a - b);
+  const parts = [];
+  let start = sorted[0];
+  let prev = sorted[0];
+  for (let i = 1; i <= sorted.length; i++) {
+    const v = sorted[i];
+    if (v === prev + 1) {
+      prev = v;
+      continue;
+    }
+    if (start === prev) parts.push(String(start));
+    else parts.push(`${start}–${prev}`);
+    start = v;
+    prev = v;
+  }
+  return parts.join(',');
+}
+
+function buildLabel(reading) {
+  if (!reading) return '';
+  const bookName = idToName(reading.book) || '';
+  const segments = [];
+  for (const r of reading.ranges || []) {
+    if (r.verses && r.verses.length) {
+      segments.push(`${r.chapter}:${compactRanges(r.verses)}`);
+    } else {
+      segments.push(String(r.chapter));
+    }
+  }
+  const ref = `${bookName} ${segments.join(';')}`.trim();
+  return reading.title ? `${reading.title}: ${ref}` : ref;
+}
+
+const META_FIELDS = [
+  'note',
+  'prayer',
+  'discussion',
+  'translation',
+  'image',
+  'link',
+  'tags',
+];
+
+function renderMeta(meta) {
+  const lines = [];
+  if (!meta) return lines;
+  for (const key of META_FIELDS) {
+    if (key === 'translation') continue; // translation shown via verses
+    if (meta[key] !== undefined) {
+      const value =
+        key === 'tags' && Array.isArray(meta[key])
+          ? meta[key].join(', ')
+          : meta[key];
+      lines.push(`${key[0].toUpperCase() + key.slice(1)}: ${value}`);
+    }
+  }
+  return lines;
+}
+
+async function openAdapter(preferred) {
+  try {
+    return await openReading(preferred);
+  } catch (err) {
+    const fallback = preferred === 'kjv' ? 'asv' : 'kjv';
+    return await openReading(fallback);
+  }
+}
+
+async function formatDayWithText(day, preferredTranslation = 'asv') {
+  const adapter = await openAdapter(preferredTranslation);
+  const lines = [];
+  const readings = Array.isArray(day.readings) ? day.readings : [];
+  for (const r of readings) {
+    lines.push(`• ${buildLabel(r)}`);
+    for (const seg of r.ranges || []) {
+      let rows;
+      if (seg.verses && seg.verses.length) {
+        rows = await adapter.getVersesSubset(r.book, seg.chapter, seg.verses);
+      } else {
+        rows = await adapter.getChapter(r.book, seg.chapter);
+      }
+      for (const row of rows) {
+        lines.push(`  ${row.verse}. ${row.text}`);
+      }
+    }
+  }
+  if (day._meta) lines.push(...renderMeta(day._meta));
+  return lines.join('\n');
+}
+
+module.exports = { formatDayWithText };
+

--- a/test/plan-format-text.test.js
+++ b/test/plan-format-text.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { formatDayWithText } = require('../src/lib/plan-format-text');
+
+test('formatDayWithText expands verses and renders metadata', async () => {
+  const day = {
+    readings: [
+      { book: 43, ranges: [{ chapter: 3, verses: [16, 17] }] },
+    ],
+    _meta: { note: 'Day note', prayer: 'Day prayer' },
+  };
+  const out = await formatDayWithText(day, 'asv');
+  assert.match(out, /• John 3:16–17/);
+  assert.match(out, /16\. For God so loved the world/);
+  assert.match(out, /17\. For God sent not the Son into the world/);
+  assert.match(out, /Note: Day note/);
+  assert.match(out, /Prayer: Day prayer/);
+});

--- a/test/planScheduler.test.js
+++ b/test/planScheduler.test.js
@@ -1,13 +1,13 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const plansDb = require('../src/db/plans');
-const { checkPlans } = require('../scheduler/planScheduler');
+const usersDb = require('../src/db/users');
 
 function yest() {
   return new Date(Date.now() - 86400000).toISOString().slice(0, 10);
 }
 
-test('checkPlans formats readings with bullets and metadata', async () => {
+test('checkPlans expands verses and metadata', async () => {
   const todayStr = new Date().toISOString().slice(0, 10);
   const dayObj = {
     readings: [
@@ -26,6 +26,7 @@ test('checkPlans formats readings with bullets and metadata', async () => {
     upd.push({ id, date });
   });
   test.mock.method(plansDb, 'resetStreak', async () => {});
+  test.mock.method(usersDb, 'getUserTranslation', async () => 'asv');
 
   const sent = [];
   const client = {
@@ -38,12 +39,16 @@ test('checkPlans formats readings with bullets and metadata', async () => {
     },
   };
 
+  // require after mocks so scheduler picks them up
+  const { checkPlans } = require('../scheduler/planScheduler');
+
   await checkPlans(client);
 
   assert.equal(sent.length, 1);
   assert.match(sent[0], /^Day 1: Start/);
-  assert.match(sent[0], /• Genesis 1/);
-  assert.match(sent[0], /• Exodus 3:16-17/);
+  assert.match(sent[0], /• Genesis 1\n  1\. In the beginning/);
+  assert.match(sent[0], /• Exodus 3:16–17\n  16\. Go, and gather/);
+  assert.match(sent[0], /17\. and I have said/);
   assert.match(sent[0], /Note: Remember to pray/);
   assert.equal(upd.length, 1);
   assert.equal(upd[0].date, todayStr);

--- a/test/translations.test.js
+++ b/test/translations.test.js
@@ -8,7 +8,6 @@ test('getVerse retrieves verse', async () => {
   const john = nameToId('John');
   const verse = await db.getVerse(john, 3, 16);
   assert.ok(verse && verse.text.includes('God'));
-  db.close();
 });
 
 test('search finds verse', async () => {
@@ -16,7 +15,6 @@ test('search finds verse', async () => {
   const results = await db.search('only begotten', 10);
   const john = nameToId('John');
   assert.ok(results.some(r => r.book === john && r.chapter === 3 && r.verse === 16));
-  db.close();
 });
 
 test('random search returns a verse', async () => {
@@ -24,7 +22,6 @@ test('random search returns a verse', async () => {
   const results = await db.search('random', 1);
   assert.equal(results.length, 1);
   assert.ok(results[0].text && results[0].book);
-  db.close();
 });
 
 test('getChapter retrieves all verses in order', async () => {
@@ -34,7 +31,6 @@ test('getChapter retrieves all verses in order', async () => {
   assert.ok(Array.isArray(verses) && verses.length > 0);
   assert.equal(verses[0].verse, 1);
   assert.ok(verses.every((v, i) => i === 0 || v.verse > verses[i - 1].verse));
-  db.close();
 });
 
 test('getVersesSubset retrieves non-contiguous verses ordered by verse', async () => {
@@ -42,7 +38,6 @@ test('getVersesSubset retrieves non-contiguous verses ordered by verse', async (
   const john = nameToId('John');
   const verses = await db.getVersesSubset(john, 3, [16, 18]);
   assert.deepEqual(verses.map(v => v.verse), [16, 18]);
-  db.close();
 });
 
 test('asv translation is supported', async () => {
@@ -50,5 +45,4 @@ test('asv translation is supported', async () => {
   const john = nameToId('John');
   const verse = await db.getVerse(john, 3, 16);
   assert.ok(verse && verse.text.includes('God'));
-  db.close();
 });


### PR DESCRIPTION
## Summary
- add `formatDayWithText` to expand plan readings with verse text and metadata
- use user's preferred translation when sending daily plan DMs via scheduler and `/brplan`
- extend tests for formatted output and verse expansion

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b75cab8e508324bc5cf6b0cb3ce8e6