### PR TITLE
fix: handle closed sqlite connections

### DIFF
--- a/src/db/translations.js
+++ b/src/db/translations.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { open } = require('./conn');
+const { open, close: closeConn } = require('./conn');
 const { pget, pall, prun, pexec } = require('./p');
 const { STRONGS_REGEX, stripStrongs } = require('./strongs');
 
@@ -38,7 +38,7 @@ async function createAdapter(translation = 'asv', options = {}) {
       return pget(db, randomSql).then((row) => maybeStrip(row) || null);
     },
     close() {
-      db.close();
+      closeConn(db);
     },
     _db: state.db,
     _cols: state.columns,

--- a/test/openReading-close.test.js
+++ b/test/openReading-close.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { openReading } = require('../src/db/openReading');
+
+// ensure repeated open/close of reading adapter works without closed db errors
+
+test('openReading returns fresh connection after close', async () => {
+  for (let i = 0; i < 2; i++) {
+    const adapter = await openReading('asv');
+    assert.ok(adapter._db.filename.endsWith('asv.sqlite'));
+    const verse = await adapter.getRandom();
+    assert.ok(verse && verse.text);
+    adapter.close();
+  }
+});
+


### PR DESCRIPTION
## Summary
- recreate sqlite database handles when cached connections are closed
- remove closed handles from connection pool on adapter close
- add regression test ensuring repeated open/close works

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b781e714608324a3cdf9e8ebbe5e11